### PR TITLE
Invariant testing integration between hyperchains

### DIFF
--- a/l1-contracts/foundry.toml
+++ b/l1-contracts/foundry.toml
@@ -14,3 +14,6 @@ fs_permissions = [
 ]
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/crates/config
+
+[invariant] #invariant section
+fail_on_revert = true

--- a/l1-contracts/scripts-rs/script-config/config-deploy-erc20.toml
+++ b/l1-contracts/scripts-rs/script-config/config-deploy-erc20.toml
@@ -8,9 +8,10 @@ decimals = 18
 implementation = "TestnetERC20Token.sol"
 mint = "10000000000"
 
-[tokens.weth]
-name = "Wrapped Ether"
-symbol = "WETH"
+[tokens.usdc]
+name = "usdc"
+symbol = "USDC"
 decimals = 18
-implementation = "WETH9.sol"
-mint = "0"
+implementation = "TestnetERC20Token.sol"
+mint = "10000000000"
+

--- a/l1-contracts/test/foundry/integration/BaseIntegrationTests.t.sol
+++ b/l1-contracts/test/foundry/integration/BaseIntegrationTests.t.sol
@@ -13,7 +13,7 @@ import {L2TxMocker} from "./_SharedL2TxMocker.t.sol";
 
 import {ETH_TOKEN_ADDRESS} from "contracts/common/Config.sol";
 import {L2_BASE_TOKEN_SYSTEM_CONTRACT_ADDR} from "contracts/common/L2ContractAddresses.sol";
-import {L2Message, TxStatus} from "contracts/common/Messaging.sol";
+import {L2Message} from "contracts/common/Messaging.sol";
 import {IMailbox} from "contracts/state-transition/chain-interfaces/IMailbox.sol";
 import {IBridgehub} from "contracts/bridgehub/IBridgehub.sol";
 
@@ -213,14 +213,14 @@ contract BaseIntegrationTests is L1ContractDeployer, HyperchainDeployer, TokenDe
         bytes32 canonicalHash = keccak256(abi.encode("CANONICAL_TX_HASH"));
         {
             bytes memory aliceSecondBridgeCalldata = abi.encode(tokenAddress, aliceDepositAmount, l2Receiver);
-            L2TransactionRequestTwoBridgesOuter memory aliceRequest = createMockL2TransactionRequestTwoBridges(
-                firstChainId,
-                mintValue,
-                0,
-                l2Value,
-                address(sharedBridge),
-                aliceSecondBridgeCalldata
-            );
+            L2TransactionRequestTwoBridgesOuter memory aliceRequest = createMockL2TransactionRequestTwoBridges({
+                _chainId: firstChainId,
+                _mintValue: mintValue,
+                _secondBridgeValue: 0,
+                _l2Value: l2Value,
+                _secondBridgeAddress: address(sharedBridge),
+                _secondBridgeCalldata: aliceSecondBridgeCalldata
+            });
 
             vm.mockCall(
                 firstHyperChainAddress,
@@ -235,14 +235,14 @@ contract BaseIntegrationTests is L1ContractDeployer, HyperchainDeployer, TokenDe
 
         {
             bytes memory bobSecondBridgeCalldata = abi.encode(tokenAddress, bobDepositAmount, l2Receiver);
-            L2TransactionRequestTwoBridgesOuter memory bobRequest = createMockL2TransactionRequestTwoBridges(
-                secondChainId,
-                mintValue,
-                0,
-                l2Value,
-                address(sharedBridge),
-                bobSecondBridgeCalldata
-            );
+            L2TransactionRequestTwoBridgesOuter memory bobRequest = createMockL2TransactionRequestTwoBridges({
+                _chainId: secondChainId,
+                _mintValue: mintValue,
+                _secondBridgeValue: 0,
+                _l2Value: l2Value,
+                _secondBridgeAddress: address(sharedBridge),
+                _secondBridgeCalldata: bobSecondBridgeCalldata
+            });
 
             vm.mockCall(
                 secondHyperChainAddress,

--- a/l1-contracts/test/foundry/integration/BaseIntegrationTests.t.sol
+++ b/l1-contracts/test/foundry/integration/BaseIntegrationTests.t.sol
@@ -14,19 +14,23 @@ import {Test} from "forge-std/Test.sol";
 import {ETH_TOKEN_ADDRESS} from "contracts/common/Config.sol";
 import {REQUIRED_L2_GAS_PRICE_PER_PUBDATA} from "contracts/common/Config.sol";
 import {Vm} from "forge-std/Vm.sol";
+import {L2CanonicalTransaction} from "contracts/common/Messaging.sol";
 
 contract BaseIntegrationTests is L1ContractDeployer, HyperchainDeployer, TokenDeployer, L2TxMocker {
     uint constant TEST_USERS_COUNT = 10;
 
-    bytes32 constant NEW_PRIORITY_REQUEST_HASH = keccak256("NewHyperchain(uint256,address)");
+    bytes32 constant NEW_PRIORITY_REQUEST_HASH =
+        keccak256(
+            "NewPriorityRequest(uint256,bytes32,uint64,(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,uint256[],bytes,bytes),bytes[])"
+        );
 
-    // event NewPriorityRequest(
-    //     uint256 txId,
-    //     bytes32 txHash,
-    //     uint64 expirationTimestamp,
-    //     L2CanonicalTransaction transaction,
-    //     bytes[] factoryDeps
-    // );
+    struct NewPriorityRequest {
+        uint256 txId;
+        bytes32 txHash;
+        uint64 expirationTimestamp;
+        L2CanonicalTransaction transaction;
+        bytes[] factoryDeps;
+    }
 
     address[] users;
     address public currentUser;
@@ -94,6 +98,22 @@ contract BaseIntegrationTests is L1ContractDeployer, HyperchainDeployer, TokenDe
         return chainMailBox.l2TransactionBaseCost(_gasPrice, _l2GasLimit, _l2GasPerPubdataByteLimit);
     }
 
+    function getNewPriorityQueueFromLogs(Vm.Log[] memory logs) internal returns (NewPriorityRequest memory request) {
+        for (uint256 i = 0; i < logs.length; i++) {
+            Vm.Log memory log = logs[i];
+
+            if (log.topics[0] == NEW_PRIORITY_REQUEST_HASH) {
+                (
+                    request.txId,
+                    request.txHash,
+                    request.expirationTimestamp,
+                    request.transaction,
+                    request.factoryDeps
+                ) = abi.decode(log.data, (uint256, bytes32, uint64, L2CanonicalTransaction, bytes[]));
+            }
+        }
+    }
+
     function depositEthToEthChainNoMock(uint256 l2Value) private {
         uint256 gasPrice = 0.01 ether;
         vm.txGasPrice(gasPrice);
@@ -124,12 +144,9 @@ contract BaseIntegrationTests is L1ContractDeployer, HyperchainDeployer, TokenDe
 
         Vm.Log[] memory logs = vm.getRecordedLogs();
 
-        for (uint i = 0; i < logs.length; i++) {
-            if (logs[i].topics[0] == NEW_PRIORITY_REQUEST_HASH) {
+        NewPriorityRequest memory request = getNewPriorityQueueFromLogs(logs);
 
-            }  
-        }
-        // assertEq(canonicalHash, resultantHash);
+        assertNotEq(request.txHash, 0);
 
         tokenSumDeposit[ETH_TOKEN_ADDRESS] += mintValue;
     }

--- a/l1-contracts/test/foundry/integration/BaseIntegrationTests.t.sol
+++ b/l1-contracts/test/foundry/integration/BaseIntegrationTests.t.sol
@@ -27,12 +27,6 @@ contract BaseIntegrationTests is L1ContractDeployer, HyperchainDeployer, TokenDe
     mapping(address chain => mapping(address token => uint256 deposited)) public depositsBridge;
     mapping(address token => uint256 deposited) public tokenSumDeposit;
 
-    // /// OLD
-    // address alice;
-    // address bob;
-
-    // TestnetERC20Token baseToken;
-
     // helper modifier to get some random user
     modifier useUser(uint256 userIndexSeed) {
         currentUser = users[bound(userIndexSeed, 0, users.length - 1)];
@@ -45,6 +39,18 @@ contract BaseIntegrationTests is L1ContractDeployer, HyperchainDeployer, TokenDe
     modifier useHyperchain(uint256 chainIndexSeed) {
         currentChainId = hyperchainIds[bound(chainIndexSeed, 0, hyperchainIds.length - 1)];
         currentChainAddress = getHyperchainAddress(currentChainId);
+        _;
+    }
+
+    modifier useGivenToken(address tokenAddress) {
+        currentToken = TestnetERC20Token(tokenAddress);
+        currentTokenAddress = tokenAddress;
+        _;
+    }
+
+    modifier useRandomToken(uint256 tokenIndexSeed) {
+        currentTokenAddress = tokens[bound(tokenIndexSeed, 0, tokens.length - 1)];
+        currentToken = TestnetERC20Token(currentTokenAddress);
         _;
     }
 
@@ -65,14 +71,40 @@ contract BaseIntegrationTests is L1ContractDeployer, HyperchainDeployer, TokenDe
         }
     }
 
-    function depositEthToBridge(
-        uint256 userIndexSeed,
-        uint256 chainIndexSeed,
-        uint256 mintValue,
-        uint256 l2Value
-    ) public virtual useUser(userIndexSeed) useHyperchain(chainIndexSeed) {
-        vm.txGasPrice(0.1 ether);
-        vm.deal(currentUser, 2 * mintValue);
+    // function depositEthToNonEthChain(
+    //     uint256 mintValue,
+    //     uint256 l2Value
+    // ) internal {
+    //     uint256 gas = 0.001 ether;
+    //     vm.txGasPrice(gas);
+    //     vm.deal(currentUser, mintValue + 10 * gas);
+
+    //     L2TransactionRequestDirect memory txRequest = createMockL2TransactionRequestDirect(
+    //         currentChainId,
+    //         mintValue,
+    //         l2Value
+    //     );
+
+    //     bytes32 canonicalHash = keccak256(abi.encode("CANONICAL_TX_HASH"));
+
+    //     vm.mockCall(
+    //         currentChainAddress,
+    //         abi.encodeWithSelector(MailboxFacet.bridgehubRequestL2Transaction.selector),
+    //         abi.encode(canonicalHash)
+    //     );
+
+    //     bytes32 resultantHash = bridgeHub.requestL2TransactionDirect(txRequest);
+    //     assertEq(canonicalHash, resultantHash);
+
+    //     depositsUsers[currentUser][ETH_TOKEN_ADDRESS] += mintValue;
+    //     depositsBridge[currentChainAddress][ETH_TOKEN_ADDRESS] += mintValue;
+    //     tokenSumDeposit[ETH_TOKEN_ADDRESS] += mintValue;
+    // }
+
+    function depositEthToEthChain(uint256 mintValue, uint256 l2Value) private {
+        uint256 gas = 0.001 ether;
+        vm.txGasPrice(gas);
+        vm.deal(currentUser, mintValue + gas);
 
         L2TransactionRequestDirect memory txRequest = createMockL2TransactionRequestDirect(
             currentChainId,
@@ -88,7 +120,7 @@ contract BaseIntegrationTests is L1ContractDeployer, HyperchainDeployer, TokenDe
             abi.encode(canonicalHash)
         );
 
-        bytes32 resultantHash = bridgeHub.requestL2TransactionDirect{value: currentUser.balance}(txRequest);
+        bytes32 resultantHash = bridgeHub.requestL2TransactionDirect{value: mintValue}(txRequest);
         assertEq(canonicalHash, resultantHash);
 
         depositsUsers[currentUser][ETH_TOKEN_ADDRESS] += mintValue;
@@ -96,16 +128,17 @@ contract BaseIntegrationTests is L1ContractDeployer, HyperchainDeployer, TokenDe
         tokenSumDeposit[ETH_TOKEN_ADDRESS] += mintValue;
     }
 
-    function depositBaseTokenToBridge(
-        uint256 userIndexSeed,
-        uint256 chainIndexSeed,
+    // deposits base ERC20 token to the bridge
+    // uses token provided as a input
+    function depositBaseERC20Token(
         uint256 mintValue,
-        uint256 l2Value
-    ) public virtual useUser(userIndexSeed) useHyperchain(chainIndexSeed) useBaseToken {
-        vm.txGasPrice(0.05 ether);
+        uint256 l2Value,
+        address tokenAddress
+    ) private useGivenToken(tokenAddress) {
+        uint256 gas = 0.05 ether;
 
-        // TODO: consider this changes balance of the user
-        vm.deal(currentUser, 0.05 ether);
+        vm.txGasPrice(gas);
+        vm.deal(currentUser, gas);
 
         currentToken.mint(currentUser, mintValue);
         assertEq(currentToken.balanceOf(currentUser), mintValue);
@@ -128,8 +161,55 @@ contract BaseIntegrationTests is L1ContractDeployer, HyperchainDeployer, TokenDe
         bytes32 resultantHash = bridgeHub.requestL2TransactionDirect(txRequest);
         assertEq(canonicalHash, resultantHash);
 
-        depositsUsers[currentUser][address(currentToken)] += mintValue;
-        depositsBridge[currentChainAddress][address(currentToken)] += l2Value;
+        depositsUsers[currentUser][currentTokenAddress] += mintValue;
+        depositsBridge[currentChainAddress][currentTokenAddress] += l2Value;
+        tokenSumDeposit[currentTokenAddress] += mintValue;
+    }
+
+    function depositEthToEthBridgeSuccess(
+        uint256 userIndexSeed,
+        uint256 chainIndexSeed,
+        uint256 mintValue,
+        uint256 l2Value
+    ) public virtual useUser(userIndexSeed) useHyperchain(chainIndexSeed) {
+        if (getHyperchainBaseToken(currentChainId) == ETH_TOKEN_ADDRESS) {
+            depositEthToEthChain(mintValue, l2Value);
+        } else {
+            // idk
+            //depositEthToNonEthChain(mintValue, l2Value);
+        }
+    }
+
+    function depositEthToEthBridgeFails(
+        uint256 userIndexSeed,
+        uint256 chainIndexSeed,
+        uint256 mintValue,
+        uint256 l2Value
+    ) public virtual useUser(userIndexSeed) useHyperchain(chainIndexSeed) {
+        if (getHyperchainBaseToken(currentChainId) == ETH_TOKEN_ADDRESS) {
+            // idk
+            //vm.expectRevert("Bridgehub: msg.value mismatch 1");
+            //depositEthToNonEthChain(mintValue, l2Value);
+        } else {
+            vm.expectRevert("Bridgehub: non-eth bridge with msg.value");
+            depositEthToEthChain(mintValue, l2Value);
+        }
+    }
+
+    function depositERC20TokenToBridgeSuccess(
+        uint256 userIndexSeed,
+        uint256 chainIndexSeed,
+        uint256 tokenIndexSeed,
+        uint256 mintValue,
+        uint256 l2Value
+    ) public virtual useUser(userIndexSeed) useHyperchain(chainIndexSeed) useRandomToken(tokenIndexSeed) {
+        address token = getHyperchainBaseToken(currentChainId);
+
+        if (currentTokenAddress == token) {
+            depositBaseERC20Token(mintValue, l2Value, currentTokenAddress);
+        } else {
+            // 2 bridges deposit
+        }
     }
 
     function prepare() public {
@@ -148,17 +228,48 @@ contract BaseIntegrationTests is L1ContractDeployer, HyperchainDeployer, TokenDe
 }
 
 contract BoundedBaseIntegrationTests is BaseIntegrationTests {
-    function depositETH(uint256 userIndexSeed, uint256 chainIndexSeed, uint256 mintValue, uint256 l2Value) external {
-        emit log_uint(mintValue);
-        vm.assume(mintValue != 0);
-        vm.assume(mintValue < l2Value);
+    function depositEthSuccess(
+        uint256 userIndexSeed,
+        uint256 chainIndexSeed,
+        uint256 mintValue,
+        uint256 l2Value
+    ) public {
+        uint64 MAX = 2 ** 64 - 1;
+        // vm.assume(mintValue != 0);
+        // vm.assume(mintValue < l2Value);
 
-        super.depositEthToBridge(userIndexSeed, chainIndexSeed, mintValue, l2Value);
+        uint256 mintValue = bound(mintValue, 0, MAX);
+        uint256 l2Value = bound(l2Value, 0, mintValue);
+
+        super.depositEthToEthBridgeSuccess(userIndexSeed, chainIndexSeed, mintValue, l2Value);
     }
 
-    function depositBase(uint256 userIndexSeed, uint256 chainIndexSeed, uint256 mintValue, uint256 l2Value) external {
-        vm.assume(mintValue > l2Value);
-        super.depositBaseTokenToBridge(userIndexSeed, chainIndexSeed, mintValue, l2Value);
+    function depositEthFail(uint256 userIndexSeed, uint256 chainIndexSeed, uint256 mintValue, uint256 l2Value) public {
+        uint64 MAX = 2 ** 64 - 1;
+        // vm.assume(mintValue != 0);
+        // vm.assume(mintValue < l2Value);
+
+        uint256 mintValue = bound(mintValue, 0, MAX);
+        uint256 l2Value = bound(l2Value, 0, mintValue);
+
+        super.depositEthToEthBridgeFails(userIndexSeed, chainIndexSeed, mintValue, l2Value);
+    }
+
+    function depositERC20Success(
+        uint256 userIndexSeed,
+        uint256 chainIndexSeed,
+        uint256 tokenIndexSeed,
+        uint256 mintValue,
+        uint256 l2Value
+    ) external {
+        uint64 MAX = 2 ** 64 - 1;
+        // vm.assume(mintValue != 0);
+        // vm.assume(mintValue < l2Value);
+
+        uint256 mintValue = bound(mintValue, 0, MAX);
+        uint256 l2Value = bound(l2Value, 0, mintValue);
+
+        super.depositERC20TokenToBridgeSuccess(userIndexSeed, chainIndexSeed, tokenIndexSeed, mintValue, l2Value);
     }
 }
 
@@ -169,23 +280,28 @@ contract InvariantTester is Test {
         tests = new BoundedBaseIntegrationTests();
         tests.prepare();
 
-        FuzzSelector memory selector = FuzzSelector({addr: address(tests), selectors: new bytes4[](1)});
+        FuzzSelector memory selector = FuzzSelector({addr: address(tests), selectors: new bytes4[](2)});
 
-        selector.selectors[0] = BoundedBaseIntegrationTests.depositETH.selector;
+        selector.selectors[0] = BoundedBaseIntegrationTests.depositEthSuccess.selector;
+        selector.selectors[1] = BoundedBaseIntegrationTests.depositERC20Success.selector;
 
         targetContract(address(tests));
         targetSelector(selector);
     }
 
-    function invariant_balanceStaysEqual() public {
+    /// forge-config: default.invariant.fail-on-revert = true
+    function invariant_ETHbalanceStaysEqual() public {
+        assertEq(tests.tokenSumDeposit(ETH_TOKEN_ADDRESS), tests.sharedBridgeProxyAddress().balance);
+    }
+
+    /// forge-config: default.invariant.fail-on-revert = true
+    function invariant_tokenbalanceStaysEqual() public {
         address tokenAddress = tests.currentTokenAddress();
-        TestnetERC20Token token = TestnetERC20Token(tokenAddress);
 
-        assertNotEq(tokenAddress, address(0));
-
-        // TODO: it shouldn't be zero, guess that test contract zeroed it
-
-        assertNotEq(0, tests.tokenSumDeposit(tokenAddress));
+        if (tokenAddress != ETH_TOKEN_ADDRESS) {
+            TestnetERC20Token token = TestnetERC20Token(tokenAddress);
+            assertEq(tests.tokenSumDeposit(tokenAddress), token.balanceOf(tests.sharedBridgeProxyAddress()));
+        }
     }
 }
 

--- a/l1-contracts/test/foundry/integration/BaseIntegrationTests.t.sol
+++ b/l1-contracts/test/foundry/integration/BaseIntegrationTests.t.sol
@@ -10,19 +10,133 @@ import {L1ContractDeployer} from "./_SharedL1ContractDeployer.t.sol";
 import {TokenDeployer} from "./_SharedTokenDeployer.t.sol";
 import {HyperchainDeployer} from "./_SharedHyperchainDeployer.t.sol";
 import {L2TxMocker} from "./_SharedL2TxMocker.t.sol";
-
+import {Test} from "forge-std/Test.sol";
 import {ETH_TOKEN_ADDRESS} from "contracts/common/Config.sol";
 
 contract BaseIntegrationTests is L1ContractDeployer, HyperchainDeployer, TokenDeployer, L2TxMocker {
-    address alice;
-    address bob;
+    uint constant TEST_USERS_COUNT = 10;
 
-    TestnetERC20Token baseToken;
+    address[] users;
+    address public currentUser;
+    uint256 public currentChainId;
+    address public currentChainAddress;
+    address public currentTokenAddress = ETH_TOKEN_ADDRESS;
+    TestnetERC20Token currentToken;
 
-    function setUp() public {
+    mapping(address user => mapping(address token => uint256 deposited)) public depositsUsers;
+    mapping(address chain => mapping(address token => uint256 deposited)) public depositsBridge;
+    mapping(address token => uint256 deposited) public tokenSumDeposit;
+
+    // /// OLD
+    // address alice;
+    // address bob;
+
+    // TestnetERC20Token baseToken;
+
+    // helper modifier to get some random user
+    modifier useUser(uint256 userIndexSeed) {
+        currentUser = users[bound(userIndexSeed, 0, users.length - 1)];
+        vm.startPrank(currentUser);
+        _;
+        vm.stopPrank();
+    }
+
+    // helper modifier to use given hyperchain
+    modifier useHyperchain(uint256 chainIndexSeed) {
+        currentChainId = hyperchainIds[bound(chainIndexSeed, 0, hyperchainIds.length - 1)];
+        currentChainAddress = getHyperchainAddress(currentChainId);
+        _;
+    }
+
+    // helper modifier to use given token
+    modifier useBaseToken() {
+        currentToken = TestnetERC20Token(getHyperchainBaseToken(currentChainId));
+        currentTokenAddress = address(currentToken);
+        _;
+    }
+
+    // generate MAX_USERS addresses and append it to testing adr
+    function generateUserAddresses() internal {
+        require(users.length == 0, "Addresses already generated");
+
+        for (uint i = 0; i < TEST_USERS_COUNT; i++) {
+            address newAddress = makeAddr(string(abi.encode("account", i)));
+            users.push(newAddress);
+        }
+    }
+
+    function depositEthToBridge(
+        uint256 userIndexSeed,
+        uint256 chainIndexSeed,
+        uint256 mintValue,
+        uint256 l2Value
+    ) public virtual useUser(userIndexSeed) useHyperchain(chainIndexSeed) {
+        vm.txGasPrice(0.1 ether);
+        vm.deal(currentUser, 2 * mintValue);
+
+        L2TransactionRequestDirect memory txRequest = createMockL2TransactionRequestDirect(
+            currentChainId,
+            mintValue,
+            l2Value
+        );
+
+        bytes32 canonicalHash = keccak256(abi.encode("CANONICAL_TX_HASH"));
+
+        vm.mockCall(
+            currentChainAddress,
+            abi.encodeWithSelector(MailboxFacet.bridgehubRequestL2Transaction.selector),
+            abi.encode(canonicalHash)
+        );
+
+        bytes32 resultantHash = bridgeHub.requestL2TransactionDirect{value: currentUser.balance}(txRequest);
+        assertEq(canonicalHash, resultantHash);
+
+        depositsUsers[currentUser][ETH_TOKEN_ADDRESS] += mintValue;
+        depositsBridge[currentChainAddress][ETH_TOKEN_ADDRESS] += mintValue;
+        tokenSumDeposit[ETH_TOKEN_ADDRESS] += mintValue;
+    }
+
+    function depositBaseTokenToBridge(
+        uint256 userIndexSeed,
+        uint256 chainIndexSeed,
+        uint256 mintValue,
+        uint256 l2Value
+    ) public virtual useUser(userIndexSeed) useHyperchain(chainIndexSeed) useBaseToken {
+        vm.txGasPrice(0.05 ether);
+
+        // TODO: consider this changes balance of the user
+        vm.deal(currentUser, 0.05 ether);
+
+        currentToken.mint(currentUser, mintValue);
+        assertEq(currentToken.balanceOf(currentUser), mintValue);
+        currentToken.approve(address(sharedBridge), mintValue);
+
+        L2TransactionRequestDirect memory txRequest = createMockL2TransactionRequestDirect(
+            currentChainId,
+            mintValue,
+            l2Value
+        );
+
+        bytes32 canonicalHash = keccak256(abi.encode("CANONICAL_TX_HASH"));
+
+        vm.mockCall(
+            currentChainAddress,
+            abi.encodeWithSelector(MailboxFacet.bridgehubRequestL2Transaction.selector),
+            abi.encode(canonicalHash)
+        );
+
+        bytes32 resultantHash = bridgeHub.requestL2TransactionDirect(txRequest);
+        assertEq(canonicalHash, resultantHash);
+
+        depositsUsers[currentUser][address(currentToken)] += mintValue;
+        depositsBridge[currentChainAddress][address(currentToken)] += l2Value;
+    }
+
+    function prepare() public {
+        generateUserAddresses();
+
         deployL1Contracts();
         deployTokens();
-
         registerNewTokens(tokens);
 
         addNewHyperchainToDeploy("hyperchain1", ETH_TOKEN_ADDRESS);
@@ -30,234 +144,310 @@ contract BaseIntegrationTests is L1ContractDeployer, HyperchainDeployer, TokenDe
         addNewHyperchainToDeploy("hyperchain3", tokens[0]);
         addNewHyperchainToDeploy("hyperchain4", tokens[0]);
         deployHyperchains();
-
-        alice = makeAddr("alice");
-        bob = makeAddr("bob");
-        baseToken = TestnetERC20Token(tokens[0]);
-    }
-
-    function test_hyperchainTokenDirectDeposit_Eth() public {
-        vm.txGasPrice(0.05 ether);
-        vm.deal(alice, 1 ether);
-        vm.deal(bob, 1 ether);
-
-        uint256 firstChainId = hyperchainIds[0];
-        uint256 secondChainId = hyperchainIds[1];
-
-        assertTrue(getHyperchainBaseToken(firstChainId) == ETH_TOKEN_ADDRESS);
-        assertTrue(getHyperchainBaseToken(secondChainId) == ETH_TOKEN_ADDRESS);
-
-        L2TransactionRequestDirect memory aliceRequest = createMockL2TransactionRequestDirect(
-            firstChainId,
-            1 ether,
-            0.1 ether
-        );
-        L2TransactionRequestDirect memory bobRequest = createMockL2TransactionRequestDirect(
-            secondChainId,
-            1 ether,
-            0.1 ether
-        );
-
-        bytes32 canonicalHash = keccak256(abi.encode("CANONICAL_TX_HASH"));
-        address firstHyperChainAddress = getHyperchainAddress(firstChainId);
-        address secondHyperChainAddress = getHyperchainAddress(secondChainId);
-
-        vm.mockCall(
-            firstHyperChainAddress,
-            abi.encodeWithSelector(MailboxFacet.bridgehubRequestL2Transaction.selector),
-            abi.encode(canonicalHash)
-        );
-
-        vm.mockCall(
-            secondHyperChainAddress,
-            abi.encodeWithSelector(MailboxFacet.bridgehubRequestL2Transaction.selector),
-            abi.encode(canonicalHash)
-        );
-
-        vm.prank(alice);
-        bytes32 resultantHash = bridgeHub.requestL2TransactionDirect{value: alice.balance}(aliceRequest);
-        assertEq(canonicalHash, resultantHash);
-
-        vm.prank(bob);
-        bytes32 resultantHash2 = bridgeHub.requestL2TransactionDirect{value: bob.balance}(bobRequest);
-        assertEq(canonicalHash, resultantHash2);
-
-        assertEq(alice.balance, 0);
-        assertEq(bob.balance, 0);
-
-        assertEq(address(sharedBridge).balance, 2 ether);
-        assertEq(sharedBridge.chainBalance(firstChainId, ETH_TOKEN_ADDRESS), 1 ether);
-        assertEq(sharedBridge.chainBalance(secondChainId, ETH_TOKEN_ADDRESS), 1 ether);
-    }
-
-    function test_hyperchainTokenDirectDeposit_NonEth() public {
-        uint256 mockMintValue = 1 ether;
-
-        vm.txGasPrice(0.05 ether);
-        vm.deal(alice, 1 ether);
-        vm.deal(bob, 1 ether);
-
-        baseToken.mint(alice, mockMintValue);
-        baseToken.mint(bob, mockMintValue);
-
-        assertEq(baseToken.balanceOf(alice), mockMintValue);
-        assertEq(baseToken.balanceOf(bob), mockMintValue);
-
-        uint256 firstChainId = hyperchainIds[2];
-        uint256 secondChainId = hyperchainIds[3];
-
-        assertTrue(getHyperchainBaseToken(firstChainId) == address(baseToken));
-        assertTrue(getHyperchainBaseToken(secondChainId) == address(baseToken));
-
-        L2TransactionRequestDirect memory aliceRequest = createMockL2TransactionRequestDirect(
-            firstChainId,
-            1 ether,
-            0.1 ether
-        );
-        L2TransactionRequestDirect memory bobRequest = createMockL2TransactionRequestDirect(
-            secondChainId,
-            1 ether,
-            0.1 ether
-        );
-
-        bytes32 canonicalHash = keccak256(abi.encode("CANONICAL_TX_HASH"));
-        address firstHyperChainAddress = getHyperchainAddress(firstChainId);
-        address secondHyperChainAddress = getHyperchainAddress(secondChainId);
-
-        vm.startPrank(alice);
-        assertEq(baseToken.balanceOf(alice), mockMintValue);
-        baseToken.approve(address(sharedBridge), mockMintValue);
-        vm.stopPrank();
-
-        vm.startPrank(bob);
-        assertEq(baseToken.balanceOf(bob), mockMintValue);
-        baseToken.approve(address(sharedBridge), mockMintValue);
-        vm.stopPrank();
-
-        vm.mockCall(
-            firstHyperChainAddress,
-            abi.encodeWithSelector(MailboxFacet.bridgehubRequestL2Transaction.selector),
-            abi.encode(canonicalHash)
-        );
-
-        vm.mockCall(
-            secondHyperChainAddress,
-            abi.encodeWithSelector(MailboxFacet.bridgehubRequestL2Transaction.selector),
-            abi.encode(canonicalHash)
-        );
-
-        vm.prank(alice);
-        bytes32 resultantHash = bridgeHub.requestL2TransactionDirect(aliceRequest);
-        assertEq(canonicalHash, resultantHash);
-
-        vm.prank(bob);
-        bytes32 resultantHash2 = bridgeHub.requestL2TransactionDirect(bobRequest);
-        assertEq(canonicalHash, resultantHash2);
-
-        // check if the balances of alice and bob are 0
-        assertEq(baseToken.balanceOf(alice), 0);
-        assertEq(baseToken.balanceOf(bob), 0);
-
-        // check if the shared bridge has the correct balances
-        assertEq(baseToken.balanceOf(address(sharedBridge)), 2 ether);
-
-        // check if the shared bridge has the correct balances for each chain
-        assertEq(sharedBridge.chainBalance(firstChainId, address(baseToken)), mockMintValue);
-        assertEq(sharedBridge.chainBalance(secondChainId, address(baseToken)), mockMintValue);
-    }
-
-    function test_hyperchainDepositNonBaseWithBaseETH() public {
-        uint256 aliceDepositAmount = 1 ether;
-        uint256 bobDepositAmount = 1.5 ether;
-
-        uint256 mintValue = 2 ether;
-        uint256 l2Value = 10000;
-        address l2Receiver = makeAddr("receiver");
-        address tokenAddress = address(baseToken);
-
-        uint256 firstChainId = hyperchainIds[0];
-        uint256 secondChainId = hyperchainIds[1];
-
-        address firstHyperChainAddress = getHyperchainAddress(firstChainId);
-        address secondHyperChainAddress = getHyperchainAddress(secondChainId);
-
-        assertTrue(getHyperchainBaseToken(firstChainId) == ETH_TOKEN_ADDRESS);
-        assertTrue(getHyperchainBaseToken(secondChainId) == ETH_TOKEN_ADDRESS);
-
-        registerL2SharedBridge(firstChainId, mockL2SharedBridge);
-        registerL2SharedBridge(secondChainId, mockL2SharedBridge);
-
-        vm.txGasPrice(0.05 ether);
-        vm.deal(alice, mintValue);
-        vm.deal(bob, mintValue);
-
-        assertEq(alice.balance, mintValue);
-        assertEq(bob.balance, mintValue);
-
-        baseToken.mint(alice, aliceDepositAmount);
-        baseToken.mint(bob, bobDepositAmount);
-
-        assertEq(baseToken.balanceOf(alice), aliceDepositAmount);
-        assertEq(baseToken.balanceOf(bob), bobDepositAmount);
-
-        vm.prank(alice);
-        baseToken.approve(address(sharedBridge), aliceDepositAmount);
-
-        vm.prank(bob);
-        baseToken.approve(address(sharedBridge), bobDepositAmount);
-
-        bytes32 canonicalHash = keccak256(abi.encode("CANONICAL_TX_HASH"));
-        {
-            bytes memory aliceSecondBridgeCalldata = abi.encode(tokenAddress, aliceDepositAmount, l2Receiver);
-            L2TransactionRequestTwoBridgesOuter memory aliceRequest = createMockL2TransactionRequestTwoBridges(
-                firstChainId,
-                mintValue,
-                0,
-                l2Value,
-                address(sharedBridge),
-                aliceSecondBridgeCalldata
-            );
-
-            vm.mockCall(
-                firstHyperChainAddress,
-                abi.encodeWithSelector(MailboxFacet.bridgehubRequestL2Transaction.selector),
-                abi.encode(canonicalHash)
-            );
-
-            vm.prank(alice);
-            bytes32 resultantHash = bridgeHub.requestL2TransactionTwoBridges{value: mintValue}(aliceRequest);
-            assertEq(canonicalHash, resultantHash);
-        }
-
-        {
-            bytes memory bobSecondBridgeCalldata = abi.encode(tokenAddress, bobDepositAmount, l2Receiver);
-            L2TransactionRequestTwoBridgesOuter memory bobRequest = createMockL2TransactionRequestTwoBridges(
-                secondChainId,
-                mintValue,
-                0,
-                l2Value,
-                address(sharedBridge),
-                bobSecondBridgeCalldata
-            );
-
-            vm.mockCall(
-                secondHyperChainAddress,
-                abi.encodeWithSelector(MailboxFacet.bridgehubRequestL2Transaction.selector),
-                abi.encode(canonicalHash)
-            );
-
-            vm.prank(bob);
-            bytes32 resultantHash2 = bridgeHub.requestL2TransactionTwoBridges{value: mintValue}(bobRequest);
-            assertEq(canonicalHash, resultantHash2);
-        }
-
-        assertEq(alice.balance, 0);
-        assertEq(bob.balance, 0);
-        assertEq(address(sharedBridge).balance, 2 * mintValue);
-        assertEq(sharedBridge.chainBalance(firstChainId, ETH_TOKEN_ADDRESS), mintValue);
-        assertEq(sharedBridge.chainBalance(secondChainId, ETH_TOKEN_ADDRESS), mintValue);
-        assertEq(sharedBridge.chainBalance(firstChainId, tokenAddress), aliceDepositAmount);
-        assertEq(sharedBridge.chainBalance(secondChainId, tokenAddress), bobDepositAmount);
-        assertEq(baseToken.balanceOf(address(sharedBridge)), aliceDepositAmount + bobDepositAmount);
     }
 }
+
+contract BoundedBaseIntegrationTests is BaseIntegrationTests {
+    function depositETH(uint256 userIndexSeed, uint256 chainIndexSeed, uint256 mintValue, uint256 l2Value) external {
+        emit log_uint(mintValue);
+        vm.assume(mintValue != 0);
+        vm.assume(mintValue < l2Value);
+
+        super.depositEthToBridge(userIndexSeed, chainIndexSeed, mintValue, l2Value);
+    }
+
+    function depositBase(uint256 userIndexSeed, uint256 chainIndexSeed, uint256 mintValue, uint256 l2Value) external {
+        vm.assume(mintValue > l2Value);
+        super.depositBaseTokenToBridge(userIndexSeed, chainIndexSeed, mintValue, l2Value);
+    }
+}
+
+contract InvariantTester is Test {
+    BoundedBaseIntegrationTests tests;
+
+    function setUp() public {
+        tests = new BoundedBaseIntegrationTests();
+        tests.prepare();
+
+        FuzzSelector memory selector = FuzzSelector({addr: address(tests), selectors: new bytes4[](1)});
+
+        selector.selectors[0] = BoundedBaseIntegrationTests.depositETH.selector;
+
+        targetContract(address(tests));
+        targetSelector(selector);
+    }
+
+    function invariant_balanceStaysEqual() public {
+        address tokenAddress = tests.currentTokenAddress();
+        TestnetERC20Token token = TestnetERC20Token(tokenAddress);
+
+        assertNotEq(tokenAddress, address(0));
+
+        // TODO: it shouldn't be zero, guess that test contract zeroed it
+
+        assertNotEq(0, tests.tokenSumDeposit(tokenAddress));
+    }
+}
+
+// function fuzzyUserDepositsEthToBridge(
+//     uint256 userIndexSeed,
+//     uint256 chainIndexSeed,
+//     uint256 mintValue,
+//     uint256 l2Value
+// ) public virtual useUser(userIndexSeed) useHyperchain(chainIndexSeed) {
+//     vm.txGasPrice(0.05 ether);
+//     vm.deal(currentUser, mintValue);
+
+//     L2TransactionRequestDirect memory txRequest = createMockL2TransactionRequestDirect(
+//         currentChainId,
+//         mintValue,
+//         l2Value
+//     );
+
+//     bytes32 canonicalHash = keccak256(abi.encode("CANONICAL_TX_HASH"));
+
+//     vm.mockCall(
+//         currentChainAddress,
+//         abi.encodeWithSelector(MailboxFacet.bridgehubRequestL2Transaction.selector),
+//         abi.encode(canonicalHash)
+//     );
+
+//     bytes32 resultantHash = bridgeHub.requestL2TransactionDirect{value: currentUser.balance}(txRequest);
+//     assertEq(canonicalHash, resultantHash);
+// }
+
+// function test_fuzzyUserDepositsEthToBridge(
+//     uint256 userIndexSeed,
+//     uint256 chainIndexSeed,
+//     uint256 mintValue,
+//     uint256 l2Value
+// ) public {
+//     // vm.assume()
+//     fuzzyUserDepositsEthToBridge(userIndexSeed, chainIndexSeed, mintValue, l2Value);
+// }
+
+// function test_hyperchainTokenDirectDeposit_Eth() public {
+//     vm.txGasPrice(0.05 ether);
+//     vm.deal(alice, 1 ether);
+//     vm.deal(bob, 1 ether);
+
+//     uint256 firstChainId = hyperchainIds[0];
+//     uint256 secondChainId = hyperchainIds[1];
+
+//     assertTrue(getHyperchainBaseToken(firstChainId) == ETH_TOKEN_ADDRESS);
+//     assertTrue(getHyperchainBaseToken(secondChainId) == ETH_TOKEN_ADDRESS);
+
+//     L2TransactionRequestDirect memory aliceRequest = createMockL2TransactionRequestDirect(
+//         firstChainId,
+//         1 ether,
+//         0.1 ether
+//     );
+//     L2TransactionRequestDirect memory bobRequest = createMockL2TransactionRequestDirect(
+//         secondChainId,
+//         1 ether,
+//         0.1 ether
+//     );
+
+//     bytes32 canonicalHash = keccak256(abi.encode("CANONICAL_TX_HASH"));
+//     address firstHyperChainAddress = getHyperchainAddress(firstChainId);
+//     address secondHyperChainAddress = getHyperchainAddress(secondChainId);
+
+//     vm.mockCall(
+//         firstHyperChainAddress,
+//         abi.encodeWithSelector(MailboxFacet.bridgehubRequestL2Transaction.selector),
+//         abi.encode(canonicalHash)
+//     );
+
+//     vm.mockCall(
+//         secondHyperChainAddress,
+//         abi.encodeWithSelector(MailboxFacet.bridgehubRequestL2Transaction.selector),
+//         abi.encode(canonicalHash)
+//     );
+
+//     vm.prank(alice);
+//     bytes32 resultantHash = bridgeHub.requestL2TransactionDirect{value: alice.balance}(aliceRequest);
+//     assertEq(canonicalHash, resultantHash);
+
+//     vm.prank(bob);
+//     bytes32 resultantHash2 = bridgeHub.requestL2TransactionDirect{value: bob.balance}(bobRequest);
+//     assertEq(canonicalHash, resultantHash2);
+
+//     assertEq(alice.balance, 0);
+//     assertEq(bob.balance, 0);
+
+//     assertEq(address(sharedBridge).balance, 2 ether);
+//     assertEq(sharedBridge.chainBalance(firstChainId, ETH_TOKEN_ADDRESS), 1 ether);
+//     assertEq(sharedBridge.chainBalance(secondChainId, ETH_TOKEN_ADDRESS), 1 ether);
+// }
+
+// function test_hyperchainTokenDirectDeposit_NonEth() public {
+//     uint256 mockMintValue = 1 ether;
+
+//     vm.txGasPrice(0.05 ether);
+//     vm.deal(alice, 1 ether);
+//     vm.deal(bob, 1 ether);
+
+//     baseToken.mint(alice, mockMintValue);
+//     baseToken.mint(bob, mockMintValue);
+
+//     assertEq(baseToken.balanceOf(alice), mockMintValue);
+//     assertEq(baseToken.balanceOf(bob), mockMintValue);
+
+//     uint256 firstChainId = hyperchainIds[2];
+//     uint256 secondChainId = hyperchainIds[3];
+
+//     assertTrue(getHyperchainBaseToken(firstChainId) == address(baseToken));
+//     assertTrue(getHyperchainBaseToken(secondChainId) == address(baseToken));
+
+//     L2TransactionRequestDirect memory aliceRequest = createMockL2TransactionRequestDirect(
+//         firstChainId,
+//         1 ether,
+//         0.1 ether
+//     );
+//     L2TransactionRequestDirect memory bobRequest = createMockL2TransactionRequestDirect(
+//         secondChainId,
+//         1 ether,
+//         0.1 ether
+//     );
+
+//     bytes32 canonicalHash = keccak256(abi.encode("CANONICAL_TX_HASH"));
+//     address firstHyperChainAddress = getHyperchainAddress(firstChainId);
+//     address secondHyperChainAddress = getHyperchainAddress(secondChainId);
+
+//     vm.startPrank(alice);
+//     assertEq(baseToken.balanceOf(alice), mockMintValue);
+//     baseToken.approve(address(sharedBridge), mockMintValue);
+//     vm.stopPrank();
+
+//     vm.startPrank(bob);
+//     assertEq(baseToken.balanceOf(bob), mockMintValue);
+//     baseToken.approve(address(sharedBridge), mockMintValue);
+//     vm.stopPrank();
+
+//     vm.mockCall(
+//         firstHyperChainAddress,
+//         abi.encodeWithSelector(MailboxFacet.bridgehubRequestL2Transaction.selector),
+//         abi.encode(canonicalHash)
+//     );
+
+//     vm.mockCall(
+//         secondHyperChainAddress,
+//         abi.encodeWithSelector(MailboxFacet.bridgehubRequestL2Transaction.selector),
+//         abi.encode(canonicalHash)
+//     );
+
+//     vm.prank(alice);
+//     bytes32 resultantHash = bridgeHub.requestL2TransactionDirect(aliceRequest);
+//     assertEq(canonicalHash, resultantHash);
+
+//     vm.prank(bob);
+//     bytes32 resultantHash2 = bridgeHub.requestL2TransactionDirect(bobRequest);
+//     assertEq(canonicalHash, resultantHash2);
+
+//     // check if the balances of alice and bob are 0
+//     assertEq(baseToken.balanceOf(alice), 0);
+//     assertEq(baseToken.balanceOf(bob), 0);
+
+//     // check if the shared bridge has the correct balances
+//     assertEq(baseToken.balanceOf(address(sharedBridge)), 2 ether);
+
+//     // check if the shared bridge has the correct balances for each chain
+//     assertEq(sharedBridge.chainBalance(firstChainId, address(baseToken)), mockMintValue);
+//     assertEq(sharedBridge.chainBalance(secondChainId, address(baseToken)), mockMintValue);
+// }
+
+// function test_hyperchainDepositNonBaseWithBaseETH() public {
+//     uint256 aliceDepositAmount = 1 ether;
+//     uint256 bobDepositAmount = 1.5 ether;
+
+//     uint256 mintValue = 2 ether;
+//     uint256 l2Value = 10000;
+//     address l2Receiver = makeAddr("receiver");
+//     address tokenAddress = address(baseToken);
+
+//     uint256 firstChainId = hyperchainIds[0];
+//     uint256 secondChainId = hyperchainIds[1];
+
+//     address firstHyperChainAddress = getHyperchainAddress(firstChainId);
+//     address secondHyperChainAddress = getHyperchainAddress(secondChainId);
+
+//     assertTrue(getHyperchainBaseToken(firstChainId) == ETH_TOKEN_ADDRESS);
+//     assertTrue(getHyperchainBaseToken(secondChainId) == ETH_TOKEN_ADDRESS);
+
+//     registerL2SharedBridge(firstChainId, mockL2SharedBridge);
+//     registerL2SharedBridge(secondChainId, mockL2SharedBridge);
+
+//     vm.txGasPrice(0.05 ether);
+//     vm.deal(alice, mintValue);
+//     vm.deal(bob, mintValue);
+
+//     assertEq(alice.balance, mintValue);
+//     assertEq(bob.balance, mintValue);
+
+//     baseToken.mint(alice, aliceDepositAmount);
+//     baseToken.mint(bob, bobDepositAmount);
+
+//     assertEq(baseToken.balanceOf(alice), aliceDepositAmount);
+//     assertEq(baseToken.balanceOf(bob), bobDepositAmount);
+
+//     vm.prank(alice);
+//     baseToken.approve(address(sharedBridge), aliceDepositAmount);
+
+//     vm.prank(bob);
+//     baseToken.approve(address(sharedBridge), bobDepositAmount);
+
+//     bytes32 canonicalHash = keccak256(abi.encode("CANONICAL_TX_HASH"));
+//     {
+//         bytes memory aliceSecondBridgeCalldata = abi.encode(tokenAddress, aliceDepositAmount, l2Receiver);
+//         L2TransactionRequestTwoBridgesOuter memory aliceRequest = createMockL2TransactionRequestTwoBridges(
+//             firstChainId,
+//             mintValue,
+//             0,
+//             l2Value,
+//             address(sharedBridge),
+//             aliceSecondBridgeCalldata
+//         );
+
+//         vm.mockCall(
+//             firstHyperChainAddress,
+//             abi.encodeWithSelector(MailboxFacet.bridgehubRequestL2Transaction.selector),
+//             abi.encode(canonicalHash)
+//         );
+
+//         vm.prank(alice);
+//         bytes32 resultantHash = bridgeHub.requestL2TransactionTwoBridges{value: mintValue}(aliceRequest);
+//         assertEq(canonicalHash, resultantHash);
+//     }
+
+//     {
+//         bytes memory bobSecondBridgeCalldata = abi.encode(tokenAddress, bobDepositAmount, l2Receiver);
+//         L2TransactionRequestTwoBridgesOuter memory bobRequest = createMockL2TransactionRequestTwoBridges(
+//             secondChainId,
+//             mintValue,
+//             0,
+//             l2Value,
+//             address(sharedBridge),
+//             bobSecondBridgeCalldata
+//         );
+
+//         vm.mockCall(
+//             secondHyperChainAddress,
+//             abi.encodeWithSelector(MailboxFacet.bridgehubRequestL2Transaction.selector),
+//             abi.encode(canonicalHash)
+//         );
+
+//         vm.prank(bob);
+//         bytes32 resultantHash2 = bridgeHub.requestL2TransactionTwoBridges{value: mintValue}(bobRequest);
+//         assertEq(canonicalHash, resultantHash2);
+//     }
+
+//     assertEq(alice.balance, 0);
+//     assertEq(bob.balance, 0);
+//     assertEq(address(sharedBridge).balance, 2 * mintValue);
+//     assertEq(sharedBridge.chainBalance(firstChainId, ETH_TOKEN_ADDRESS), mintValue);
+//     assertEq(sharedBridge.chainBalance(secondChainId, ETH_TOKEN_ADDRESS), mintValue);
+//     assertEq(sharedBridge.chainBalance(firstChainId, tokenAddress), aliceDepositAmount);
+//     assertEq(sharedBridge.chainBalance(secondChainId, tokenAddress), bobDepositAmount);
+//     assertEq(baseToken.balanceOf(address(sharedBridge)), aliceDepositAmount + bobDepositAmount);
+// }
+//}

--- a/l1-contracts/test/foundry/integration/BaseIntegrationTests.t.sol
+++ b/l1-contracts/test/foundry/integration/BaseIntegrationTests.t.sol
@@ -12,6 +12,10 @@ import {HyperchainDeployer} from "./_SharedHyperchainDeployer.t.sol";
 import {L2TxMocker} from "./_SharedL2TxMocker.t.sol";
 
 import {ETH_TOKEN_ADDRESS} from "contracts/common/Config.sol";
+import {L2_BASE_TOKEN_SYSTEM_CONTRACT_ADDR} from "contracts/common/L2ContractAddresses.sol";
+import {L2Message, TxStatus} from "contracts/common/Messaging.sol";
+import {IMailbox} from "contracts/state-transition/chain-interfaces/IMailbox.sol";
+import {IBridgehub} from "contracts/bridgehub/IBridgehub.sol";
 
 contract BaseIntegrationTests is L1ContractDeployer, HyperchainDeployer, TokenDeployer, L2TxMocker {
     address alice;
@@ -259,5 +263,51 @@ contract BaseIntegrationTests is L1ContractDeployer, HyperchainDeployer, TokenDe
         assertEq(sharedBridge.chainBalance(firstChainId, tokenAddress), aliceDepositAmount);
         assertEq(sharedBridge.chainBalance(secondChainId, tokenAddress), bobDepositAmount);
         assertEq(baseToken.balanceOf(address(sharedBridge)), aliceDepositAmount + bobDepositAmount);
+    }
+
+    function test_hyperchainFinalizeWithdrawal() public {
+        uint256 amountToWithdraw = 1 ether;
+        _setSharedBridgeChainBalance(10, ETH_TOKEN_ADDRESS, amountToWithdraw);
+
+        uint256 l2BatchNumber = uint256(uint160(makeAddr("l2BatchNumber")));
+        uint256 l2MessageIndex = uint256(uint160(makeAddr("l2MessageIndex")));
+        uint16 l2TxNumberInBatch = uint16(uint160(makeAddr("l2TxNumberInBatch")));
+        bytes32[] memory merkleProof = new bytes32[](1);
+        uint256 chainId = 10;
+
+        vm.deal(address(sharedBridge), amountToWithdraw);
+
+        bytes memory message = abi.encodePacked(IMailbox.finalizeEthWithdrawal.selector, alice, amountToWithdraw);
+        L2Message memory l2ToL1Message = L2Message({
+            txNumberInBatch: l2TxNumberInBatch,
+            sender: L2_BASE_TOKEN_SYSTEM_CONTRACT_ADDR,
+            data: message
+        });
+
+        vm.mockCall(
+            bridgehubProxyAddress,
+            // solhint-disable-next-line func-named-parameters
+            abi.encodeWithSelector(
+                IBridgehub.proveL2MessageInclusion.selector,
+                chainId,
+                l2BatchNumber,
+                l2MessageIndex,
+                l2ToL1Message,
+                merkleProof
+            ),
+            abi.encode(true)
+        );
+
+        sharedBridge.finalizeWithdrawal({
+            _chainId: chainId,
+            _l2BatchNumber: l2BatchNumber,
+            _l2MessageIndex: l2MessageIndex,
+            _l2TxNumberInBatch: l2TxNumberInBatch,
+            _message: message,
+            _merkleProof: merkleProof
+        });
+
+        assertEq(alice.balance, amountToWithdraw);
+        assertEq(address(sharedBridge).balance, 0);
     }
 }

--- a/l1-contracts/test/foundry/integration/BaseIntegrationTests.t.sol
+++ b/l1-contracts/test/foundry/integration/BaseIntegrationTests.t.sol
@@ -42,6 +42,9 @@ contract BaseIntegrationTests is L1ContractDeployer, HyperchainDeployer, TokenDe
     mapping(address user => mapping(address token => uint256 deposited)) public depositsUsers;
     mapping(address chain => mapping(address token => uint256 deposited)) public depositsBridge;
     mapping(address token => uint256 deposited) public tokenSumDeposit;
+    mapping(address token => uint256 deposited) public l2ValuesSum;
+
+    mapping(address l2contract => uint256 balance) public l2contractBalances;
 
     // helper modifier to get some random user
     modifier useUser(uint256 userIndexSeed) {
@@ -98,6 +101,31 @@ contract BaseIntegrationTests is L1ContractDeployer, HyperchainDeployer, TokenDe
         return chainMailBox.l2TransactionBaseCost(_gasPrice, _l2GasLimit, _l2GasPerPubdataByteLimit);
     }
 
+    function handleRequestByMockL2Contract(NewPriorityRequest memory request) internal returns (uint256) {
+        address payable contractAddress = payable(address(uint160(uint256(request.transaction.to))));
+
+        address someMockAddress = makeAddr("mocked");
+
+        emit log_uint(l2contractBalances[contractAddress]);
+
+        uint256 toSend = request.transaction.value;
+        vm.deal(someMockAddress, toSend);
+
+        vm.startPrank(someMockAddress);
+        bool sent = contractAddress.send(toSend);
+        vm.stopPrank();
+
+        l2contractBalances[contractAddress] += toSend;
+
+        emit log_uint(l2contractBalances[contractAddress]);
+
+        assertEq(contractAddress.balance, l2contractBalances[contractAddress]);
+
+        assertEq(sent, true);
+
+        return toSend;
+    }
+
     function getNewPriorityQueueFromLogs(Vm.Log[] memory logs) internal returns (NewPriorityRequest memory request) {
         for (uint256 i = 0; i < logs.length; i++) {
             Vm.Log memory log = logs[i];
@@ -148,7 +176,11 @@ contract BaseIntegrationTests is L1ContractDeployer, HyperchainDeployer, TokenDe
 
         assertNotEq(request.txHash, 0);
 
+        uint256 sent = handleRequestByMockL2Contract(request);
+        assertEq(sent, l2Value);
+
         tokenSumDeposit[ETH_TOKEN_ADDRESS] += mintValue;
+        l2ValuesSum[ETH_TOKEN_ADDRESS] += l2Value;
     }
 
     function depositEthToEthChain(uint256 mintValue, uint256 l2Value) private {
@@ -287,6 +319,11 @@ contract BaseIntegrationTests is L1ContractDeployer, HyperchainDeployer, TokenDe
         addNewHyperchainToDeploy("hyperchain3", tokens[0]);
         addNewHyperchainToDeploy("hyperchain4", tokens[0]);
         deployHyperchains();
+
+        for (uint256 i = 0; i < hyperchainIds.length; i++) {
+            address contractAddress = makeAddr(string(abi.encode("contract", i)));
+            addL2ChainContract(hyperchainIds[i], contractAddress);
+        }
     }
 }
 
@@ -340,7 +377,7 @@ contract BoundedBaseIntegrationTests is BaseIntegrationTests {
         // vm.assume(mintValue != 0);
         // vm.assume(mintValue < l2Value);
         // uint256 mintValue = bound(mintValue, 0, MAX);
-        uint256 l2Value = bound(l2Value, 0, MAX);
+        uint256 l2Value = bound(l2Value, 0.1 ether, MAX);
 
         super.depositEthToEthChainNoMockSuccess(userIndexSeed, chainIndexSeed, l2Value);
     }
@@ -364,6 +401,20 @@ contract InvariantTesterNoMock is Test {
     /// forge-config: default.invariant.fail-on-revert = true
     function invariant_ETHbalanceStaysEqual() public {
         assertEq(tests.tokenSumDeposit(ETH_TOKEN_ADDRESS), tests.sharedBridgeProxyAddress().balance);
+    }
+
+    /// forge-config: default.invariant.fail-on-revert = true
+    function invariant_balaceOnContractsEqualsSharedBridge() public {
+        uint256 sum = 0;
+
+        for (uint256 i = 0; i < 5; i++) {
+            address l2Contract = tests.chainContracts(tests.hyperchainIds(i));
+
+            sum += l2Contract.balance;
+        }
+
+        // emit log_uint(tests.l2ValuesSum(ETH_TOKEN_ADDRESS));
+        assertEq(tests.l2ValuesSum(ETH_TOKEN_ADDRESS), sum);
     }
 }
 

--- a/l1-contracts/test/foundry/integration/BaseIntegrationTests.t.sol
+++ b/l1-contracts/test/foundry/integration/BaseIntegrationTests.t.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.24;
 
 import {L2TransactionRequestDirect, L2TransactionRequestTwoBridgesOuter} from "contracts/bridgehub/IBridgehub.sol";
 import {TestnetERC20Token} from "contracts/dev-contracts/TestnetERC20Token.sol";
-
 import {MailboxFacet} from "contracts/state-transition/chain-deps/facets/Mailbox.sol";
+import {IMailbox} from "contracts//state-transition/chain-interfaces/IMailbox.sol";
 
 import {L1ContractDeployer} from "./_SharedL1ContractDeployer.t.sol";
 import {TokenDeployer} from "./_SharedTokenDeployer.t.sol";
@@ -12,9 +12,21 @@ import {HyperchainDeployer} from "./_SharedHyperchainDeployer.t.sol";
 import {L2TxMocker} from "./_SharedL2TxMocker.t.sol";
 import {Test} from "forge-std/Test.sol";
 import {ETH_TOKEN_ADDRESS} from "contracts/common/Config.sol";
+import {REQUIRED_L2_GAS_PRICE_PER_PUBDATA} from "contracts/common/Config.sol";
+import {Vm} from "forge-std/Vm.sol";
 
 contract BaseIntegrationTests is L1ContractDeployer, HyperchainDeployer, TokenDeployer, L2TxMocker {
     uint constant TEST_USERS_COUNT = 10;
+
+    bytes32 constant NEW_PRIORITY_REQUEST_HASH = keccak256("NewHyperchain(uint256,address)");
+
+    // event NewPriorityRequest(
+    //     uint256 txId,
+    //     bytes32 txHash,
+    //     uint64 expirationTimestamp,
+    //     L2CanonicalTransaction transaction,
+    //     bytes[] factoryDeps
+    // );
 
     address[] users;
     address public currentUser;
@@ -71,38 +83,59 @@ contract BaseIntegrationTests is L1ContractDeployer, HyperchainDeployer, TokenDe
         }
     }
 
-    // function depositEthToNonEthChain(
-    //     uint256 mintValue,
-    //     uint256 l2Value
-    // ) internal {
-    //     uint256 gas = 0.001 ether;
-    //     vm.txGasPrice(gas);
-    //     vm.deal(currentUser, mintValue + 10 * gas);
+    function getMinRequiredGasPriceForChain(
+        uint256 _chainId,
+        uint256 _gasPrice,
+        uint256 _l2GasLimit,
+        uint256 _l2GasPerPubdataByteLimit
+    ) public view returns (uint256) {
+        MailboxFacet chainMailBox = MailboxFacet(getHyperchainAddress(_chainId));
 
-    //     L2TransactionRequestDirect memory txRequest = createMockL2TransactionRequestDirect(
-    //         currentChainId,
-    //         mintValue,
-    //         l2Value
-    //     );
+        return chainMailBox.l2TransactionBaseCost(_gasPrice, _l2GasLimit, _l2GasPerPubdataByteLimit);
+    }
 
-    //     bytes32 canonicalHash = keccak256(abi.encode("CANONICAL_TX_HASH"));
+    function depositEthToEthChainNoMock(uint256 l2Value) private {
+        uint256 gasPrice = 0.01 ether;
+        vm.txGasPrice(gasPrice);
 
-    //     vm.mockCall(
-    //         currentChainAddress,
-    //         abi.encodeWithSelector(MailboxFacet.bridgehubRequestL2Transaction.selector),
-    //         abi.encode(canonicalHash)
-    //     );
+        uint256 l2GasLimit = 70000000; // reverts with 8
+        uint256 minRequiredGas = getMinRequiredGasPriceForChain(
+            currentChainId,
+            gasPrice,
+            l2GasLimit,
+            REQUIRED_L2_GAS_PRICE_PER_PUBDATA
+        );
 
-    //     bytes32 resultantHash = bridgeHub.requestL2TransactionDirect(txRequest);
-    //     assertEq(canonicalHash, resultantHash);
+        uint256 mintValue = l2Value + minRequiredGas;
 
-    //     depositsUsers[currentUser][ETH_TOKEN_ADDRESS] += mintValue;
-    //     depositsBridge[currentChainAddress][ETH_TOKEN_ADDRESS] += mintValue;
-    //     tokenSumDeposit[ETH_TOKEN_ADDRESS] += mintValue;
-    // }
+        vm.deal(currentUser, mintValue);
+
+        L2TransactionRequestDirect memory txRequest = createL2TransitionRequestDirectSecond(
+            currentChainId,
+            mintValue,
+            l2Value,
+            l2GasLimit,
+            REQUIRED_L2_GAS_PRICE_PER_PUBDATA
+        );
+
+        vm.recordLogs();
+
+        bytes32 resultantHash = bridgeHub.requestL2TransactionDirect{value: mintValue}(txRequest);
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        for (uint i = 0; i < logs.length; i++) {
+            if (logs[i].topics[0] == NEW_PRIORITY_REQUEST_HASH) {
+
+            }  
+        }
+        // assertEq(canonicalHash, resultantHash);
+
+        tokenSumDeposit[ETH_TOKEN_ADDRESS] += mintValue;
+    }
 
     function depositEthToEthChain(uint256 mintValue, uint256 l2Value) private {
-        uint256 gas = 0.001 ether;
+        uint256 gas = 0 ether;
         vm.txGasPrice(gas);
         vm.deal(currentUser, mintValue + gas);
 
@@ -212,6 +245,19 @@ contract BaseIntegrationTests is L1ContractDeployer, HyperchainDeployer, TokenDe
         }
     }
 
+    function depositEthToEthChainNoMockSuccess(
+        uint256 userIndexSeed,
+        uint256 chainIndexSeed,
+        uint256 l2Value
+    ) public virtual useUser(userIndexSeed) useHyperchain(chainIndexSeed) {
+        if (getHyperchainBaseToken(currentChainId) == ETH_TOKEN_ADDRESS) {
+            depositEthToEthChainNoMock(l2Value);
+        } else {
+            // idk
+            //depositEthToNonEthChain(mintValue, l2Value);
+        }
+    }
+
     function prepare() public {
         generateUserAddresses();
 
@@ -261,7 +307,7 @@ contract BoundedBaseIntegrationTests is BaseIntegrationTests {
         uint256 tokenIndexSeed,
         uint256 mintValue,
         uint256 l2Value
-    ) external {
+    ) public {
         uint64 MAX = 2 ** 64 - 1;
         // vm.assume(mintValue != 0);
         // vm.assume(mintValue < l2Value);
@@ -270,6 +316,37 @@ contract BoundedBaseIntegrationTests is BaseIntegrationTests {
         uint256 l2Value = bound(l2Value, 0, mintValue);
 
         super.depositERC20TokenToBridgeSuccess(userIndexSeed, chainIndexSeed, tokenIndexSeed, mintValue, l2Value);
+    }
+
+    function depositEthNoMock(uint256 userIndexSeed, uint256 chainIndexSeed, uint256 l2Value) public {
+        uint64 MAX = 2 ** 64 - 1;
+        // vm.assume(mintValue != 0);
+        // vm.assume(mintValue < l2Value);
+        // uint256 mintValue = bound(mintValue, 0, MAX);
+        uint256 l2Value = bound(l2Value, 0, MAX);
+
+        super.depositEthToEthChainNoMockSuccess(userIndexSeed, chainIndexSeed, l2Value);
+    }
+}
+
+contract InvariantTesterNoMock is Test {
+    BoundedBaseIntegrationTests tests;
+
+    function setUp() public {
+        tests = new BoundedBaseIntegrationTests();
+        tests.prepare();
+
+        FuzzSelector memory selector = FuzzSelector({addr: address(tests), selectors: new bytes4[](1)});
+
+        selector.selectors[0] = BoundedBaseIntegrationTests.depositEthNoMock.selector;
+
+        targetContract(address(tests));
+        targetSelector(selector);
+    }
+
+    /// forge-config: default.invariant.fail-on-revert = true
+    function invariant_ETHbalanceStaysEqual() public {
+        assertEq(tests.tokenSumDeposit(ETH_TOKEN_ADDRESS), tests.sharedBridgeProxyAddress().balance);
     }
 }
 

--- a/l1-contracts/test/foundry/integration/BaseIntegrationTests.t.sol
+++ b/l1-contracts/test/foundry/integration/BaseIntegrationTests.t.sol
@@ -43,8 +43,7 @@ contract BaseIntegrationTests is L1ContractDeployer, HyperchainDeployer, TokenDe
     mapping(address chain => mapping(address token => uint256 deposited)) public depositsBridge;
     mapping(address token => uint256 deposited) public tokenSumDeposit;
     mapping(address token => uint256 deposited) public l2ValuesSum;
-
-    mapping(address l2contract => uint256 balance) public l2contractBalances;
+    mapping(address l2contract => mapping(address token => uint256 balance)) public l2contractBalances;
 
     // helper modifier to get some random user
     modifier useUser(uint256 userIndexSeed) {
@@ -101,29 +100,37 @@ contract BaseIntegrationTests is L1ContractDeployer, HyperchainDeployer, TokenDe
         return chainMailBox.l2TransactionBaseCost(_gasPrice, _l2GasLimit, _l2GasPerPubdataByteLimit);
     }
 
-    function handleRequestByMockL2Contract(NewPriorityRequest memory request) internal returns (uint256) {
+    function handleRequestByMockL2Contract(NewPriorityRequest memory request) internal {
         address payable contractAddress = payable(address(uint160(uint256(request.transaction.to))));
-
         address someMockAddress = makeAddr("mocked");
-
-        emit log_uint(l2contractBalances[contractAddress]);
-
         uint256 toSend = request.transaction.value;
-        vm.deal(someMockAddress, toSend);
+        address tokenAddress = abi.decode(request.transaction.data, (address));
+        uint256 balanceAfter = 0;
 
-        vm.startPrank(someMockAddress);
-        bool sent = contractAddress.send(toSend);
-        vm.stopPrank();
+        if (tokenAddress == ETH_TOKEN_ADDRESS) {
+            vm.deal(someMockAddress, toSend);
 
-        l2contractBalances[contractAddress] += toSend;
+            vm.startPrank(someMockAddress);
+            bool sent = contractAddress.send(toSend);
+            vm.stopPrank();
+            assertEq(sent, true);
 
-        emit log_uint(l2contractBalances[contractAddress]);
+            balanceAfter = contractAddress.balance;
+        } else {
+            TestnetERC20Token token = TestnetERC20Token(tokenAddress);
+            token.mint(someMockAddress, toSend);
 
-        assertEq(contractAddress.balance, l2contractBalances[contractAddress]);
+            vm.startPrank(someMockAddress);
+            token.approve(someMockAddress, toSend);
+            bool sent = token.transferFrom(someMockAddress, contractAddress, toSend);
+            vm.stopPrank();
+            assertEq(sent, true);
 
-        assertEq(sent, true);
+            balanceAfter = token.balanceOf(contractAddress);
+        }
 
-        return toSend;
+        l2contractBalances[contractAddress][tokenAddress] += toSend;
+        assertEq(balanceAfter, l2contractBalances[contractAddress][tokenAddress]);
     }
 
     function getNewPriorityQueueFromLogs(Vm.Log[] memory logs) internal returns (NewPriorityRequest memory request) {
@@ -142,7 +149,7 @@ contract BaseIntegrationTests is L1ContractDeployer, HyperchainDeployer, TokenDe
         }
     }
 
-    function depositEthToEthChainNoMock(uint256 l2Value) private {
+    function depositEthToEthChain(uint256 l2Value) private {
         uint256 gasPrice = 0.01 ether;
         vm.txGasPrice(gasPrice);
 
@@ -155,7 +162,6 @@ contract BaseIntegrationTests is L1ContractDeployer, HyperchainDeployer, TokenDe
         );
 
         uint256 mintValue = l2Value + minRequiredGas;
-
         vm.deal(currentUser, mintValue);
 
         L2TransactionRequestDirect memory txRequest = createL2TransitionRequestDirectSecond(
@@ -163,99 +169,76 @@ contract BaseIntegrationTests is L1ContractDeployer, HyperchainDeployer, TokenDe
             mintValue,
             l2Value,
             l2GasLimit,
-            REQUIRED_L2_GAS_PRICE_PER_PUBDATA
+            REQUIRED_L2_GAS_PRICE_PER_PUBDATA,
+            ETH_TOKEN_ADDRESS
         );
 
         vm.recordLogs();
-
         bytes32 resultantHash = bridgeHub.requestL2TransactionDirect{value: mintValue}(txRequest);
-
         Vm.Log[] memory logs = vm.getRecordedLogs();
 
         NewPriorityRequest memory request = getNewPriorityQueueFromLogs(logs);
-
         assertNotEq(request.txHash, 0);
 
-        uint256 sent = handleRequestByMockL2Contract(request);
-        assertEq(sent, l2Value);
-
-        tokenSumDeposit[ETH_TOKEN_ADDRESS] += mintValue;
-        l2ValuesSum[ETH_TOKEN_ADDRESS] += l2Value;
-    }
-
-    function depositEthToEthChain(uint256 mintValue, uint256 l2Value) private {
-        uint256 gas = 0 ether;
-        vm.txGasPrice(gas);
-        vm.deal(currentUser, mintValue + gas);
-
-        L2TransactionRequestDirect memory txRequest = createMockL2TransactionRequestDirect(
-            currentChainId,
-            mintValue,
-            l2Value
-        );
-
-        bytes32 canonicalHash = keccak256(abi.encode("CANONICAL_TX_HASH"));
-
-        vm.mockCall(
-            currentChainAddress,
-            abi.encodeWithSelector(MailboxFacet.bridgehubRequestL2Transaction.selector),
-            abi.encode(canonicalHash)
-        );
-
-        bytes32 resultantHash = bridgeHub.requestL2TransactionDirect{value: mintValue}(txRequest);
-        assertEq(canonicalHash, resultantHash);
+        handleRequestByMockL2Contract(request);
 
         depositsUsers[currentUser][ETH_TOKEN_ADDRESS] += mintValue;
         depositsBridge[currentChainAddress][ETH_TOKEN_ADDRESS] += mintValue;
         tokenSumDeposit[ETH_TOKEN_ADDRESS] += mintValue;
+        l2ValuesSum[ETH_TOKEN_ADDRESS] += l2Value;
     }
 
     // deposits base ERC20 token to the bridge
     // uses token provided as a input
-    function depositBaseERC20Token(
-        uint256 mintValue,
-        uint256 l2Value,
-        address tokenAddress
-    ) private useGivenToken(tokenAddress) {
-        uint256 gas = 0.05 ether;
+    function depositBaseERC20Token(uint256 l2Value, address tokenAddress) private useGivenToken(tokenAddress) {
+        uint256 gasPrice = 0.01 ether;
+        vm.txGasPrice(gasPrice);
+        vm.deal(currentUser, gasPrice);
 
-        vm.txGasPrice(gas);
-        vm.deal(currentUser, gas);
+        uint256 l2GasLimit = 70000000; // reverts with 8
+        uint256 minRequiredGas = getMinRequiredGasPriceForChain(
+            currentChainId,
+            gasPrice,
+            l2GasLimit,
+            REQUIRED_L2_GAS_PRICE_PER_PUBDATA
+        );
 
+        uint256 mintValue = l2Value + minRequiredGas;
         currentToken.mint(currentUser, mintValue);
         assertEq(currentToken.balanceOf(currentUser), mintValue);
         currentToken.approve(address(sharedBridge), mintValue);
 
-        L2TransactionRequestDirect memory txRequest = createMockL2TransactionRequestDirect(
+        L2TransactionRequestDirect memory txRequest = createL2TransitionRequestDirectSecond(
             currentChainId,
             mintValue,
-            l2Value
+            l2Value,
+            l2GasLimit,
+            REQUIRED_L2_GAS_PRICE_PER_PUBDATA,
+            tokenAddress
         );
 
-        bytes32 canonicalHash = keccak256(abi.encode("CANONICAL_TX_HASH"));
-
-        vm.mockCall(
-            currentChainAddress,
-            abi.encodeWithSelector(MailboxFacet.bridgehubRequestL2Transaction.selector),
-            abi.encode(canonicalHash)
-        );
-
+        vm.recordLogs();
         bytes32 resultantHash = bridgeHub.requestL2TransactionDirect(txRequest);
-        assertEq(canonicalHash, resultantHash);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        NewPriorityRequest memory request = getNewPriorityQueueFromLogs(logs);
+        assertNotEq(request.txHash, 0);
+
+        handleRequestByMockL2Contract(request);
 
         depositsUsers[currentUser][currentTokenAddress] += mintValue;
-        depositsBridge[currentChainAddress][currentTokenAddress] += l2Value;
+        depositsBridge[currentChainAddress][currentTokenAddress] += mintValue;
         tokenSumDeposit[currentTokenAddress] += mintValue;
+        l2ValuesSum[currentTokenAddress] += l2Value;
     }
 
     function depositEthToEthBridgeSuccess(
         uint256 userIndexSeed,
         uint256 chainIndexSeed,
-        uint256 mintValue,
         uint256 l2Value
     ) public virtual useUser(userIndexSeed) useHyperchain(chainIndexSeed) {
         if (getHyperchainBaseToken(currentChainId) == ETH_TOKEN_ADDRESS) {
-            depositEthToEthChain(mintValue, l2Value);
+            depositEthToEthChain(l2Value);
         } else {
             // idk
             //depositEthToNonEthChain(mintValue, l2Value);
@@ -265,7 +248,6 @@ contract BaseIntegrationTests is L1ContractDeployer, HyperchainDeployer, TokenDe
     function depositEthToEthBridgeFails(
         uint256 userIndexSeed,
         uint256 chainIndexSeed,
-        uint256 mintValue,
         uint256 l2Value
     ) public virtual useUser(userIndexSeed) useHyperchain(chainIndexSeed) {
         if (getHyperchainBaseToken(currentChainId) == ETH_TOKEN_ADDRESS) {
@@ -274,7 +256,7 @@ contract BaseIntegrationTests is L1ContractDeployer, HyperchainDeployer, TokenDe
             //depositEthToNonEthChain(mintValue, l2Value);
         } else {
             vm.expectRevert("Bridgehub: non-eth bridge with msg.value");
-            depositEthToEthChain(mintValue, l2Value);
+            depositEthToEthChain(l2Value);
         }
     }
 
@@ -282,28 +264,14 @@ contract BaseIntegrationTests is L1ContractDeployer, HyperchainDeployer, TokenDe
         uint256 userIndexSeed,
         uint256 chainIndexSeed,
         uint256 tokenIndexSeed,
-        uint256 mintValue,
         uint256 l2Value
     ) public virtual useUser(userIndexSeed) useHyperchain(chainIndexSeed) useRandomToken(tokenIndexSeed) {
         address token = getHyperchainBaseToken(currentChainId);
 
         if (currentTokenAddress == token) {
-            depositBaseERC20Token(mintValue, l2Value, currentTokenAddress);
+            depositBaseERC20Token(l2Value, currentTokenAddress);
         } else {
             // 2 bridges deposit
-        }
-    }
-
-    function depositEthToEthChainNoMockSuccess(
-        uint256 userIndexSeed,
-        uint256 chainIndexSeed,
-        uint256 l2Value
-    ) public virtual useUser(userIndexSeed) useHyperchain(chainIndexSeed) {
-        if (getHyperchainBaseToken(currentChainId) == ETH_TOKEN_ADDRESS) {
-            depositEthToEthChainNoMock(l2Value);
-        } else {
-            // idk
-            //depositEthToNonEthChain(mintValue, l2Value);
         }
     }
 
@@ -328,93 +296,30 @@ contract BaseIntegrationTests is L1ContractDeployer, HyperchainDeployer, TokenDe
 }
 
 contract BoundedBaseIntegrationTests is BaseIntegrationTests {
-    function depositEthSuccess(
-        uint256 userIndexSeed,
-        uint256 chainIndexSeed,
-        uint256 mintValue,
-        uint256 l2Value
-    ) public {
+    function depositEthSuccess(uint256 userIndexSeed, uint256 chainIndexSeed, uint256 l2Value) public {
         uint64 MAX = 2 ** 64 - 1;
-        // vm.assume(mintValue != 0);
-        // vm.assume(mintValue < l2Value);
+        uint256 l2Value = bound(l2Value, 0.1 ether, MAX);
 
-        uint256 mintValue = bound(mintValue, 0, MAX);
-        uint256 l2Value = bound(l2Value, 0, mintValue);
-
-        super.depositEthToEthBridgeSuccess(userIndexSeed, chainIndexSeed, mintValue, l2Value);
+        super.depositEthToEthBridgeSuccess(userIndexSeed, chainIndexSeed, l2Value);
     }
 
-    function depositEthFail(uint256 userIndexSeed, uint256 chainIndexSeed, uint256 mintValue, uint256 l2Value) public {
+    function depositEthFail(uint256 userIndexSeed, uint256 chainIndexSeed, uint256 l2Value) public {
         uint64 MAX = 2 ** 64 - 1;
-        // vm.assume(mintValue != 0);
-        // vm.assume(mintValue < l2Value);
+        uint256 l2Value = bound(l2Value, 0.1 ether, MAX);
 
-        uint256 mintValue = bound(mintValue, 0, MAX);
-        uint256 l2Value = bound(l2Value, 0, mintValue);
-
-        super.depositEthToEthBridgeFails(userIndexSeed, chainIndexSeed, mintValue, l2Value);
+        super.depositEthToEthBridgeFails(userIndexSeed, chainIndexSeed, l2Value);
     }
 
     function depositERC20Success(
         uint256 userIndexSeed,
         uint256 chainIndexSeed,
         uint256 tokenIndexSeed,
-        uint256 mintValue,
         uint256 l2Value
     ) public {
         uint64 MAX = 2 ** 64 - 1;
-        // vm.assume(mintValue != 0);
-        // vm.assume(mintValue < l2Value);
-
-        uint256 mintValue = bound(mintValue, 0, MAX);
-        uint256 l2Value = bound(l2Value, 0, mintValue);
-
-        super.depositERC20TokenToBridgeSuccess(userIndexSeed, chainIndexSeed, tokenIndexSeed, mintValue, l2Value);
-    }
-
-    function depositEthNoMock(uint256 userIndexSeed, uint256 chainIndexSeed, uint256 l2Value) public {
-        uint64 MAX = 2 ** 64 - 1;
-        // vm.assume(mintValue != 0);
-        // vm.assume(mintValue < l2Value);
-        // uint256 mintValue = bound(mintValue, 0, MAX);
         uint256 l2Value = bound(l2Value, 0.1 ether, MAX);
 
-        super.depositEthToEthChainNoMockSuccess(userIndexSeed, chainIndexSeed, l2Value);
-    }
-}
-
-contract InvariantTesterNoMock is Test {
-    BoundedBaseIntegrationTests tests;
-
-    function setUp() public {
-        tests = new BoundedBaseIntegrationTests();
-        tests.prepare();
-
-        FuzzSelector memory selector = FuzzSelector({addr: address(tests), selectors: new bytes4[](1)});
-
-        selector.selectors[0] = BoundedBaseIntegrationTests.depositEthNoMock.selector;
-
-        targetContract(address(tests));
-        targetSelector(selector);
-    }
-
-    /// forge-config: default.invariant.fail-on-revert = true
-    function invariant_ETHbalanceStaysEqual() public {
-        assertEq(tests.tokenSumDeposit(ETH_TOKEN_ADDRESS), tests.sharedBridgeProxyAddress().balance);
-    }
-
-    /// forge-config: default.invariant.fail-on-revert = true
-    function invariant_balaceOnContractsEqualsSharedBridge() public {
-        uint256 sum = 0;
-
-        for (uint256 i = 0; i < 5; i++) {
-            address l2Contract = tests.chainContracts(tests.hyperchainIds(i));
-
-            sum += l2Contract.balance;
-        }
-
-        // emit log_uint(tests.l2ValuesSum(ETH_TOKEN_ADDRESS));
-        assertEq(tests.l2ValuesSum(ETH_TOKEN_ADDRESS), sum);
+        super.depositERC20TokenToBridgeSuccess(userIndexSeed, chainIndexSeed, tokenIndexSeed, l2Value);
     }
 }
 
@@ -428,6 +333,7 @@ contract InvariantTester is Test {
         FuzzSelector memory selector = FuzzSelector({addr: address(tests), selectors: new bytes4[](2)});
 
         selector.selectors[0] = BoundedBaseIntegrationTests.depositEthSuccess.selector;
+        // selector.selectors[1] = BoundedBaseIntegrationTests.depositEthFail.selector;
         selector.selectors[1] = BoundedBaseIntegrationTests.depositERC20Success.selector;
 
         targetContract(address(tests));
@@ -447,6 +353,20 @@ contract InvariantTester is Test {
             TestnetERC20Token token = TestnetERC20Token(tokenAddress);
             assertEq(tests.tokenSumDeposit(tokenAddress), token.balanceOf(tests.sharedBridgeProxyAddress()));
         }
+    }
+
+    /// forge-config: default.invariant.fail-on-revert = true
+    function invariant_balaceOnContractsEqualsSharedBridge() public {
+        uint256 sum = 0;
+
+        for (uint256 i = 0; i < 5; i++) {
+            address l2Contract = tests.chainContracts(tests.hyperchainIds(i));
+
+            sum += l2Contract.balance;
+        }
+
+        // emit log_uint(tests.l2ValuesSum(ETH_TOKEN_ADDRESS));
+        assertEq(tests.l2ValuesSum(ETH_TOKEN_ADDRESS), sum);
     }
 }
 

--- a/l1-contracts/test/foundry/integration/BridgeHubInvariantTests.t.sol
+++ b/l1-contracts/test/foundry/integration/BridgeHubInvariantTests.t.sol
@@ -15,6 +15,8 @@ import {ETH_TOKEN_ADDRESS} from "contracts/common/Config.sol";
 import {REQUIRED_L2_GAS_PRICE_PER_PUBDATA} from "contracts/common/Config.sol";
 import {Vm} from "forge-std/Vm.sol";
 import {L2CanonicalTransaction} from "contracts/common/Messaging.sol";
+import {IL2Bridge} from "contracts/bridge/interfaces/IL2Bridge.sol";
+import {UnsafeBytes} from "contracts/common/libraries/UnsafeBytes.sol";
 
 contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, TokenDeployer, L2TxMocker {
     uint constant TEST_USERS_COUNT = 10;
@@ -43,7 +45,8 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
     mapping(address chain => mapping(address token => uint256 deposited)) public depositsBridge;
     mapping(address token => uint256 deposited) public tokenSumDeposit;
     mapping(address token => uint256 deposited) public l2ValuesSum;
-    mapping(address l2contract => mapping(address token => uint256 balance)) public l2contractBalances;
+    mapping(address l2contract => mapping(address token => uint256 balance)) public contractDeposits;
+    mapping(address token => uint256 deposited) public contractDepositsSum;
 
     // helper modifier to get some random user
     modifier useUser(uint256 userIndexSeed) {
@@ -79,6 +82,19 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
         _;
     }
 
+    modifier useERC20Token(uint256 tokenIndexSeed) {
+        currentTokenAddress = tokens[bound(tokenIndexSeed, 0, tokens.length - 1)];
+
+        while (currentTokenAddress == ETH_TOKEN_ADDRESS) {
+            tokenIndexSeed += 1;
+            currentTokenAddress = tokens[bound(tokenIndexSeed, 0, tokens.length - 1)];
+        }
+
+        currentToken = TestnetERC20Token(currentTokenAddress);
+
+        _;
+    }
+
     // generate MAX_USERS addresses and append it to testing adr
     function generateUserAddresses() internal {
         require(users.length == 0, "Addresses already generated");
@@ -100,11 +116,43 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
         return chainMailBox.l2TransactionBaseCost(_gasPrice, _l2GasLimit, _l2GasPerPubdataByteLimit);
     }
 
+    function getDecodedDepositL2Calldata(
+        bytes memory callData
+    ) internal view returns (address l1Sender, address l2Receiver, address l1Token, uint256 amount, bytes memory b) {
+        // UnsafeBytes approach doesn't work, because abi is not deterministic in this approach i guess
+        bytes memory slicedData = new bytes(callData.length - 4);
+
+        for (uint i = 4; i < callData.length; i++) {
+            slicedData[i - 4] = callData[i];
+        }
+
+        (l1Sender, l2Receiver, l1Token, amount, b) = abi.decode(
+            slicedData,
+            (address, address, address, uint256, bytes)
+        );
+    }
+
     function handleRequestByMockL2Contract(NewPriorityRequest memory request) internal {
         address payable contractAddress = payable(address(uint160(uint256(request.transaction.to))));
         address someMockAddress = makeAddr("mocked");
-        uint256 toSend = request.transaction.value;
-        address tokenAddress = abi.decode(request.transaction.data, (address));
+        // uint256 toSend; // = request.transaction.value; //ETH CASE
+
+        address tokenAddress;
+        address receiver;
+        uint256 toSend;
+        address l1Sender;
+
+        uint256 requestLength = request.transaction.data.length;
+        bytes memory temp;
+
+        if (requestLength == 612) {
+            (l1Sender, receiver, tokenAddress, toSend, temp) = getDecodedDepositL2Calldata(request.transaction.data);
+        } else {
+            (tokenAddress, toSend, receiver) = abi.decode(request.transaction.data, (address, uint256, address));
+        }
+
+        assertEq(contractAddress, receiver);
+
         uint256 balanceAfter = 0;
 
         if (tokenAddress == ETH_TOKEN_ADDRESS) {
@@ -129,8 +177,12 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
             balanceAfter = token.balanceOf(contractAddress);
         }
 
-        l2contractBalances[contractAddress][tokenAddress] += toSend;
-        assertEq(balanceAfter, l2contractBalances[contractAddress][tokenAddress]);
+        emit log_string("received");
+        emit log_uint(toSend);
+
+        contractDeposits[contractAddress][tokenAddress] += toSend;
+        contractDepositsSum[tokenAddress] += toSend;
+        assertEq(balanceAfter, contractDeposits[contractAddress][tokenAddress]);
     }
 
     function getNewPriorityQueueFromLogs(Vm.Log[] memory logs) internal returns (NewPriorityRequest memory request) {
@@ -149,6 +201,57 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
         }
     }
 
+    function depositNonEthToEthChain(uint256 l2Value, address tokenAddress) private useGivenToken(tokenAddress) {
+        uint256 gasPrice = 0.01 ether;
+        vm.txGasPrice(gasPrice);
+
+        uint256 l2GasLimit = 70000000; // reverts with 8
+        uint256 minRequiredGas = getMinRequiredGasPriceForChain(
+            currentChainId,
+            gasPrice,
+            l2GasLimit,
+            REQUIRED_L2_GAS_PRICE_PER_PUBDATA
+        );
+
+        uint256 mintValue = minRequiredGas;
+        vm.deal(currentUser, mintValue);
+
+        currentToken.mint(currentUser, l2Value);
+        assertEq(currentToken.balanceOf(currentUser), l2Value);
+        currentToken.approve(address(sharedBridge), l2Value);
+
+        bytes memory secondBridgeCallData = abi.encode(currentTokenAddress, l2Value, chainContracts[currentChainId]);
+        L2TransactionRequestTwoBridgesOuter memory requestTx = createMockL2TransactionRequestTwoBridgesSecond(
+            currentChainId,
+            mintValue,
+            0,
+            address(sharedBridge),
+            0, // L2 VALUE WHICH IS ALWAYS 0
+            l2GasLimit,
+            REQUIRED_L2_GAS_PRICE_PER_PUBDATA,
+            secondBridgeCallData
+        );
+
+        vm.recordLogs();
+        bytes32 resultantHash = bridgeHub.requestL2TransactionTwoBridges{value: mintValue}(requestTx);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        NewPriorityRequest memory request = getNewPriorityQueueFromLogs(logs);
+        assertNotEq(request.txHash, 0);
+
+        emit log_string("sent");
+        emit log_uint(l2Value);
+
+        handleRequestByMockL2Contract(request);
+        depositsUsers[currentUser][ETH_TOKEN_ADDRESS] += mintValue;
+        depositsBridge[currentChainAddress][ETH_TOKEN_ADDRESS] += mintValue;
+        tokenSumDeposit[ETH_TOKEN_ADDRESS] += mintValue;
+
+        depositsUsers[currentUser][currentTokenAddress] += l2Value;
+        depositsBridge[currentChainAddress][currentTokenAddress] += l2Value;
+        tokenSumDeposit[currentTokenAddress] += l2Value;
+        l2ValuesSum[currentTokenAddress] += l2Value;
+    }
+
     function depositEthToEthChain(uint256 l2Value) private {
         uint256 gasPrice = 0.01 ether;
         vm.txGasPrice(gasPrice);
@@ -164,13 +267,15 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
         uint256 mintValue = l2Value + minRequiredGas;
         vm.deal(currentUser, mintValue);
 
+        bytes memory callData = abi.encode(currentTokenAddress, l2Value, chainContracts[currentChainId]);
         L2TransactionRequestDirect memory txRequest = createL2TransitionRequestDirectSecond(
             currentChainId,
             mintValue,
             l2Value,
             l2GasLimit,
             REQUIRED_L2_GAS_PRICE_PER_PUBDATA,
-            ETH_TOKEN_ADDRESS
+            ETH_TOKEN_ADDRESS,
+            callData
         );
 
         vm.recordLogs();
@@ -190,7 +295,7 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
 
     // deposits base ERC20 token to the bridge
     // uses token provided as a input
-    function depositBaseERC20Token(uint256 l2Value, address tokenAddress) private useGivenToken(tokenAddress) {
+    function depositERC20Base(uint256 l2Value) private useBaseToken {
         uint256 gasPrice = 0.01 ether;
         vm.txGasPrice(gasPrice);
         vm.deal(currentUser, gasPrice);
@@ -208,13 +313,15 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
         assertEq(currentToken.balanceOf(currentUser), mintValue);
         currentToken.approve(address(sharedBridge), mintValue);
 
+        bytes memory callData = abi.encode(currentTokenAddress, l2Value, chainContracts[currentChainId]);
         L2TransactionRequestDirect memory txRequest = createL2TransitionRequestDirectSecond(
             currentChainId,
             mintValue,
             l2Value,
             l2GasLimit,
             REQUIRED_L2_GAS_PRICE_PER_PUBDATA,
-            tokenAddress
+            currentTokenAddress,
+            callData
         );
 
         vm.recordLogs();
@@ -265,13 +372,17 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
         uint256 chainIndexSeed,
         uint256 tokenIndexSeed,
         uint256 l2Value
-    ) public virtual useUser(userIndexSeed) useHyperchain(chainIndexSeed) useRandomToken(tokenIndexSeed) {
-        address token = getHyperchainBaseToken(currentChainId);
+    ) public virtual useUser(userIndexSeed) useHyperchain(chainIndexSeed) useERC20Token(tokenIndexSeed) {
+        address chainBaseToken = getHyperchainBaseToken(currentChainId);
 
-        if (currentTokenAddress == token) {
-            depositBaseERC20Token(l2Value, currentTokenAddress);
+        if (chainBaseToken == ETH_TOKEN_ADDRESS) {
+            depositNonEthToEthChain(l2Value, currentTokenAddress);
         } else {
-            // 2 bridges deposit
+            if (currentTokenAddress == chainBaseToken) {
+                depositERC20Base(l2Value);
+            } else {
+                // depositNonEthToNonEthChain(l2Value, currentTokenAddress);
+            }
         }
     }
 
@@ -291,6 +402,8 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
         for (uint256 i = 0; i < hyperchainIds.length; i++) {
             address contractAddress = makeAddr(string(abi.encode("contract", i)));
             addL2ChainContract(hyperchainIds[i], contractAddress);
+
+            registerL2SharedBridge(hyperchainIds[i], contractAddress);
         }
     }
 }
@@ -332,303 +445,75 @@ contract InvariantTester is Test {
 
         FuzzSelector memory selector = FuzzSelector({addr: address(tests), selectors: new bytes4[](2)});
 
-        selector.selectors[0] = BoundedBridgeHubInvariantTests.depositEthSuccess.selector;
-        // selector.selectors[1] = BoundedBridgeHubInvariantTests.depositEthFail.selector;
-        selector.selectors[1] = BoundedBridgeHubInvariantTests.depositERC20Success.selector;
+        selector.selectors[0] = BoundedBridgeHubInvariantTests.depositERC20Success.selector;
+        selector.selectors[1] = BoundedBridgeHubInvariantTests.depositEthSuccess.selector;
+        // selector.selectors[1] = BoundedBridgeHubInvariantTests.depositERC20Success.selector;
 
         targetContract(address(tests));
         targetSelector(selector);
     }
 
-    /// forge-config: default.invariant.fail-on-revert = true
-    function invariant_ETHbalanceStaysEqual() public {
+    // check wether eth sum of deposits shadowed between tests and updated on each deposit
+    // equals balance of L1Shared bridge
+    /// forge-config: default.invariant.fail-on-revert = false
+    function invariant_ETHSumEqualsBalance() public {
         assertEq(tests.tokenSumDeposit(ETH_TOKEN_ADDRESS), tests.sharedBridgeProxyAddress().balance);
     }
 
-    /// forge-config: default.invariant.fail-on-revert = true
-    function invariant_tokenbalanceStaysEqual() public {
-        address tokenAddress = tests.currentTokenAddress();
-
-        if (tokenAddress != ETH_TOKEN_ADDRESS) {
-            TestnetERC20Token token = TestnetERC20Token(tokenAddress);
-            assertEq(tests.tokenSumDeposit(tokenAddress), token.balanceOf(tests.sharedBridgeProxyAddress()));
+    // check wether current token sum of deposits shadowed between tests and updated on each deposit
+    // equals balance of L1Shared bridge
+    /// forge-config: default.invariant.fail-on-revert = false
+    function invariant_currentTokenSumEqualsBalance() public {
+        address currentTokenAddress = tests.currentTokenAddress();
+        if (currentTokenAddress != ETH_TOKEN_ADDRESS) {
+            TestnetERC20Token token = TestnetERC20Token(currentTokenAddress);
+            assertEq(
+                tests.tokenSumDeposit(tests.currentTokenAddress()),
+                token.balanceOf(tests.sharedBridgeProxyAddress())
+            );
         }
     }
 
-    /// forge-config: default.invariant.fail-on-revert = true
-    function invariant_balaceOnContractsEqualsSharedBridge() public {
+    // check if sum of ETH part which is send to L2 contract, registered by this test suite
+    // is equals actual sum of balances of l2 contracts (which are mocked, but read events from logs)
+    /// forge-config: default.invariant.fail-on-revert = false
+    function invariant_ETHbalaceOnContractsDeposited() public {
         uint256 sum = 0;
 
         for (uint256 i = 0; i < 5; i++) {
             address l2Contract = tests.chainContracts(tests.hyperchainIds(i));
+            uint256 balance = l2Contract.balance;
 
-            sum += l2Contract.balance;
+            assertEq(tests.contractDeposits(l2Contract, ETH_TOKEN_ADDRESS), balance);
+            sum += balance;
         }
 
-        // emit log_uint(tests.l2ValuesSum(ETH_TOKEN_ADDRESS));
         assertEq(tests.l2ValuesSum(ETH_TOKEN_ADDRESS), sum);
+        assertEq(tests.contractDepositsSum(ETH_TOKEN_ADDRESS), sum);
+        assertEq(tests.l2ValuesSum(ETH_TOKEN_ADDRESS), tests.contractDepositsSum(ETH_TOKEN_ADDRESS));
+    }
+
+    // check if sum of currentToken part which is send to L2 contract, registered by this test suite
+    // is equals actual sum of balances of l2 contracts (which are mocked, but read events from logs)
+    /// forge-config: default.invariant.fail-on-revert = false
+    function invariant_currentTokenBalaceOnContractsEqualsDeposited() public {
+        address currentTokenAddress = tests.currentTokenAddress();
+        uint256 sum = 0;
+
+        if (currentTokenAddress == ETH_TOKEN_ADDRESS) {
+            return;
+        }
+
+        for (uint256 i = 0; i < 5; i++) {
+            TestnetERC20Token token = TestnetERC20Token(currentTokenAddress);
+            address l2Contract = tests.chainContracts(tests.hyperchainIds(i));
+            uint256 balance = token.balanceOf(l2Contract);
+            assertEq(tests.contractDeposits(l2Contract, ETH_TOKEN_ADDRESS), balance);
+            sum += balance;
+        }
+
+        assertEq(tests.l2ValuesSum(currentTokenAddress), sum);
+        assertEq(tests.contractDepositsSum(currentTokenAddress), sum);
+        assertEq(tests.l2ValuesSum(currentTokenAddress), tests.contractDepositsSum(currentTokenAddress));
     }
 }
-
-// function fuzzyUserDepositsEthToBridge(
-//     uint256 userIndexSeed,
-//     uint256 chainIndexSeed,
-//     uint256 mintValue,
-//     uint256 l2Value
-// ) public virtual useUser(userIndexSeed) useHyperchain(chainIndexSeed) {
-//     vm.txGasPrice(0.05 ether);
-//     vm.deal(currentUser, mintValue);
-
-//     L2TransactionRequestDirect memory txRequest = createMockL2TransactionRequestDirect(
-//         currentChainId,
-//         mintValue,
-//         l2Value
-//     );
-
-//     bytes32 canonicalHash = keccak256(abi.encode("CANONICAL_TX_HASH"));
-
-//     vm.mockCall(
-//         currentChainAddress,
-//         abi.encodeWithSelector(MailboxFacet.bridgehubRequestL2Transaction.selector),
-//         abi.encode(canonicalHash)
-//     );
-
-//     bytes32 resultantHash = bridgeHub.requestL2TransactionDirect{value: currentUser.balance}(txRequest);
-//     assertEq(canonicalHash, resultantHash);
-// }
-
-// function test_fuzzyUserDepositsEthToBridge(
-//     uint256 userIndexSeed,
-//     uint256 chainIndexSeed,
-//     uint256 mintValue,
-//     uint256 l2Value
-// ) public {
-//     // vm.assume()
-//     fuzzyUserDepositsEthToBridge(userIndexSeed, chainIndexSeed, mintValue, l2Value);
-// }
-
-// function test_hyperchainTokenDirectDeposit_Eth() public {
-//     vm.txGasPrice(0.05 ether);
-//     vm.deal(alice, 1 ether);
-//     vm.deal(bob, 1 ether);
-
-//     uint256 firstChainId = hyperchainIds[0];
-//     uint256 secondChainId = hyperchainIds[1];
-
-//     assertTrue(getHyperchainBaseToken(firstChainId) == ETH_TOKEN_ADDRESS);
-//     assertTrue(getHyperchainBaseToken(secondChainId) == ETH_TOKEN_ADDRESS);
-
-//     L2TransactionRequestDirect memory aliceRequest = createMockL2TransactionRequestDirect(
-//         firstChainId,
-//         1 ether,
-//         0.1 ether
-//     );
-//     L2TransactionRequestDirect memory bobRequest = createMockL2TransactionRequestDirect(
-//         secondChainId,
-//         1 ether,
-//         0.1 ether
-//     );
-
-//     bytes32 canonicalHash = keccak256(abi.encode("CANONICAL_TX_HASH"));
-//     address firstHyperChainAddress = getHyperchainAddress(firstChainId);
-//     address secondHyperChainAddress = getHyperchainAddress(secondChainId);
-
-//     vm.mockCall(
-//         firstHyperChainAddress,
-//         abi.encodeWithSelector(MailboxFacet.bridgehubRequestL2Transaction.selector),
-//         abi.encode(canonicalHash)
-//     );
-
-//     vm.mockCall(
-//         secondHyperChainAddress,
-//         abi.encodeWithSelector(MailboxFacet.bridgehubRequestL2Transaction.selector),
-//         abi.encode(canonicalHash)
-//     );
-
-//     vm.prank(alice);
-//     bytes32 resultantHash = bridgeHub.requestL2TransactionDirect{value: alice.balance}(aliceRequest);
-//     assertEq(canonicalHash, resultantHash);
-
-//     vm.prank(bob);
-//     bytes32 resultantHash2 = bridgeHub.requestL2TransactionDirect{value: bob.balance}(bobRequest);
-//     assertEq(canonicalHash, resultantHash2);
-
-//     assertEq(alice.balance, 0);
-//     assertEq(bob.balance, 0);
-
-//     assertEq(address(sharedBridge).balance, 2 ether);
-//     assertEq(sharedBridge.chainBalance(firstChainId, ETH_TOKEN_ADDRESS), 1 ether);
-//     assertEq(sharedBridge.chainBalance(secondChainId, ETH_TOKEN_ADDRESS), 1 ether);
-// }
-
-// function test_hyperchainTokenDirectDeposit_NonEth() public {
-//     uint256 mockMintValue = 1 ether;
-
-//     vm.txGasPrice(0.05 ether);
-//     vm.deal(alice, 1 ether);
-//     vm.deal(bob, 1 ether);
-
-//     baseToken.mint(alice, mockMintValue);
-//     baseToken.mint(bob, mockMintValue);
-
-//     assertEq(baseToken.balanceOf(alice), mockMintValue);
-//     assertEq(baseToken.balanceOf(bob), mockMintValue);
-
-//     uint256 firstChainId = hyperchainIds[2];
-//     uint256 secondChainId = hyperchainIds[3];
-
-//     assertTrue(getHyperchainBaseToken(firstChainId) == address(baseToken));
-//     assertTrue(getHyperchainBaseToken(secondChainId) == address(baseToken));
-
-//     L2TransactionRequestDirect memory aliceRequest = createMockL2TransactionRequestDirect(
-//         firstChainId,
-//         1 ether,
-//         0.1 ether
-//     );
-//     L2TransactionRequestDirect memory bobRequest = createMockL2TransactionRequestDirect(
-//         secondChainId,
-//         1 ether,
-//         0.1 ether
-//     );
-
-//     bytes32 canonicalHash = keccak256(abi.encode("CANONICAL_TX_HASH"));
-//     address firstHyperChainAddress = getHyperchainAddress(firstChainId);
-//     address secondHyperChainAddress = getHyperchainAddress(secondChainId);
-
-//     vm.startPrank(alice);
-//     assertEq(baseToken.balanceOf(alice), mockMintValue);
-//     baseToken.approve(address(sharedBridge), mockMintValue);
-//     vm.stopPrank();
-
-//     vm.startPrank(bob);
-//     assertEq(baseToken.balanceOf(bob), mockMintValue);
-//     baseToken.approve(address(sharedBridge), mockMintValue);
-//     vm.stopPrank();
-
-//     vm.mockCall(
-//         firstHyperChainAddress,
-//         abi.encodeWithSelector(MailboxFacet.bridgehubRequestL2Transaction.selector),
-//         abi.encode(canonicalHash)
-//     );
-
-//     vm.mockCall(
-//         secondHyperChainAddress,
-//         abi.encodeWithSelector(MailboxFacet.bridgehubRequestL2Transaction.selector),
-//         abi.encode(canonicalHash)
-//     );
-
-//     vm.prank(alice);
-//     bytes32 resultantHash = bridgeHub.requestL2TransactionDirect(aliceRequest);
-//     assertEq(canonicalHash, resultantHash);
-
-//     vm.prank(bob);
-//     bytes32 resultantHash2 = bridgeHub.requestL2TransactionDirect(bobRequest);
-//     assertEq(canonicalHash, resultantHash2);
-
-//     // check if the balances of alice and bob are 0
-//     assertEq(baseToken.balanceOf(alice), 0);
-//     assertEq(baseToken.balanceOf(bob), 0);
-
-//     // check if the shared bridge has the correct balances
-//     assertEq(baseToken.balanceOf(address(sharedBridge)), 2 ether);
-
-//     // check if the shared bridge has the correct balances for each chain
-//     assertEq(sharedBridge.chainBalance(firstChainId, address(baseToken)), mockMintValue);
-//     assertEq(sharedBridge.chainBalance(secondChainId, address(baseToken)), mockMintValue);
-// }
-
-// function test_hyperchainDepositNonBaseWithBaseETH() public {
-//     uint256 aliceDepositAmount = 1 ether;
-//     uint256 bobDepositAmount = 1.5 ether;
-
-//     uint256 mintValue = 2 ether;
-//     uint256 l2Value = 10000;
-//     address l2Receiver = makeAddr("receiver");
-//     address tokenAddress = address(baseToken);
-
-//     uint256 firstChainId = hyperchainIds[0];
-//     uint256 secondChainId = hyperchainIds[1];
-
-//     address firstHyperChainAddress = getHyperchainAddress(firstChainId);
-//     address secondHyperChainAddress = getHyperchainAddress(secondChainId);
-
-//     assertTrue(getHyperchainBaseToken(firstChainId) == ETH_TOKEN_ADDRESS);
-//     assertTrue(getHyperchainBaseToken(secondChainId) == ETH_TOKEN_ADDRESS);
-
-//     registerL2SharedBridge(firstChainId, mockL2SharedBridge);
-//     registerL2SharedBridge(secondChainId, mockL2SharedBridge);
-
-//     vm.txGasPrice(0.05 ether);
-//     vm.deal(alice, mintValue);
-//     vm.deal(bob, mintValue);
-
-//     assertEq(alice.balance, mintValue);
-//     assertEq(bob.balance, mintValue);
-
-//     baseToken.mint(alice, aliceDepositAmount);
-//     baseToken.mint(bob, bobDepositAmount);
-
-//     assertEq(baseToken.balanceOf(alice), aliceDepositAmount);
-//     assertEq(baseToken.balanceOf(bob), bobDepositAmount);
-
-//     vm.prank(alice);
-//     baseToken.approve(address(sharedBridge), aliceDepositAmount);
-
-//     vm.prank(bob);
-//     baseToken.approve(address(sharedBridge), bobDepositAmount);
-
-//     bytes32 canonicalHash = keccak256(abi.encode("CANONICAL_TX_HASH"));
-//     {
-//         bytes memory aliceSecondBridgeCalldata = abi.encode(tokenAddress, aliceDepositAmount, l2Receiver);
-//         L2TransactionRequestTwoBridgesOuter memory aliceRequest = createMockL2TransactionRequestTwoBridges(
-//             firstChainId,
-//             mintValue,
-//             0,
-//             l2Value,
-//             address(sharedBridge),
-//             aliceSecondBridgeCalldata
-//         );
-
-//         vm.mockCall(
-//             firstHyperChainAddress,
-//             abi.encodeWithSelector(MailboxFacet.bridgehubRequestL2Transaction.selector),
-//             abi.encode(canonicalHash)
-//         );
-
-//         vm.prank(alice);
-//         bytes32 resultantHash = bridgeHub.requestL2TransactionTwoBridges{value: mintValue}(aliceRequest);
-//         assertEq(canonicalHash, resultantHash);
-//     }
-
-//     {
-//         bytes memory bobSecondBridgeCalldata = abi.encode(tokenAddress, bobDepositAmount, l2Receiver);
-//         L2TransactionRequestTwoBridgesOuter memory bobRequest = createMockL2TransactionRequestTwoBridges(
-//             secondChainId,
-//             mintValue,
-//             0,
-//             l2Value,
-//             address(sharedBridge),
-//             bobSecondBridgeCalldata
-//         );
-
-//         vm.mockCall(
-//             secondHyperChainAddress,
-//             abi.encodeWithSelector(MailboxFacet.bridgehubRequestL2Transaction.selector),
-//             abi.encode(canonicalHash)
-//         );
-
-//         vm.prank(bob);
-//         bytes32 resultantHash2 = bridgeHub.requestL2TransactionTwoBridges{value: mintValue}(bobRequest);
-//         assertEq(canonicalHash, resultantHash2);
-//     }
-
-//     assertEq(alice.balance, 0);
-//     assertEq(bob.balance, 0);
-//     assertEq(address(sharedBridge).balance, 2 * mintValue);
-//     assertEq(sharedBridge.chainBalance(firstChainId, ETH_TOKEN_ADDRESS), mintValue);
-//     assertEq(sharedBridge.chainBalance(secondChainId, ETH_TOKEN_ADDRESS), mintValue);
-//     assertEq(sharedBridge.chainBalance(firstChainId, tokenAddress), aliceDepositAmount);
-//     assertEq(sharedBridge.chainBalance(secondChainId, tokenAddress), bobDepositAmount);
-//     assertEq(baseToken.balanceOf(address(sharedBridge)), aliceDepositAmount + bobDepositAmount);
-// }
-//}

--- a/l1-contracts/test/foundry/integration/BridgeHubInvariantTests.t.sol
+++ b/l1-contracts/test/foundry/integration/BridgeHubInvariantTests.t.sol
@@ -4,7 +4,12 @@ pragma solidity 0.8.24;
 import {L2TransactionRequestDirect, L2TransactionRequestTwoBridgesOuter} from "contracts/bridgehub/IBridgehub.sol";
 import {TestnetERC20Token} from "contracts/dev-contracts/TestnetERC20Token.sol";
 import {MailboxFacet} from "contracts/state-transition/chain-deps/facets/Mailbox.sol";
-import {IMailbox} from "contracts//state-transition/chain-interfaces/IMailbox.sol";
+import {GettersFacet} from "contracts/state-transition/chain-deps/facets/Getters.sol";
+import {IMailbox} from "contracts/state-transition/chain-interfaces/IMailbox.sol";
+import {IExecutor} from "contracts/state-transition/chain-interfaces/IExecutor.sol";
+import {IGetters} from "contracts/state-transition/chain-interfaces/IGetters.sol";
+
+import {IStateTransitionManager} from "contracts/state-transition/IStateTransitionManager.sol";
 
 import {L1ContractDeployer} from "./_SharedL1ContractDeployer.t.sol";
 import {TokenDeployer} from "./_SharedTokenDeployer.t.sol";
@@ -12,7 +17,7 @@ import {HyperchainDeployer} from "./_SharedHyperchainDeployer.t.sol";
 import {L2TxMocker} from "./_SharedL2TxMocker.t.sol";
 import {Test} from "forge-std/Test.sol";
 import {ETH_TOKEN_ADDRESS} from "contracts/common/Config.sol";
-import {REQUIRED_L2_GAS_PRICE_PER_PUBDATA} from "contracts/common/Config.sol";
+import {REQUIRED_L2_GAS_PRICE_PER_PUBDATA, COMMIT_TIMESTAMP_NOT_OLDER, DEFAULT_L2_LOGS_TREE_ROOT_HASH, EMPTY_STRING_KECCAK} from "contracts/common/Config.sol";
 import {Vm} from "forge-std/Vm.sol";
 import {L2CanonicalTransaction} from "contracts/common/Messaging.sol";
 import {IL2Bridge} from "contracts/bridge/interfaces/IL2Bridge.sol";
@@ -41,14 +46,20 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
     address public currentTokenAddress = ETH_TOKEN_ADDRESS;
     TestnetERC20Token currentToken;
 
+    // amounts deposited by the user, mapped by token
     mapping(address user => mapping(address token => uint256 deposited)) public depositsUsers;
+    // amounts deposited into the bridge, mapped by hyperchain and token
     mapping(address chain => mapping(address token => uint256 deposited)) public depositsBridge;
+    // sum of deposits into the bridge, mapped by token address
     mapping(address token => uint256 deposited) public tokenSumDeposit;
+    // sum of l2values which were transfered to some mock contract, mapped by token address
     mapping(address token => uint256 deposited) public l2ValuesSum;
+    // deposits into the hyperchains contract, mapped by token address
     mapping(address l2contract => mapping(address token => uint256 balance)) public contractDeposits;
+    // sum of deposits into all the l2 contracts, mapped by token
     mapping(address token => uint256 deposited) public contractDepositsSum;
 
-    // helper modifier to get some random user
+    // gets random user from users array, sets currentUser
     modifier useUser(uint256 userIndexSeed) {
         currentUser = users[bound(userIndexSeed, 0, users.length - 1)];
         vm.startPrank(currentUser);
@@ -56,32 +67,37 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
         vm.stopPrank();
     }
 
-    // helper modifier to use given hyperchain
+    // gets random hyperchain from hyperchain ids, sets currentChainId and currentChainAddress
     modifier useHyperchain(uint256 chainIndexSeed) {
         currentChainId = hyperchainIds[bound(chainIndexSeed, 0, hyperchainIds.length - 1)];
         currentChainAddress = getHyperchainAddress(currentChainId);
         _;
     }
 
+    // use token specified by address
     modifier useGivenToken(address tokenAddress) {
         currentToken = TestnetERC20Token(tokenAddress);
         currentTokenAddress = tokenAddress;
         _;
     }
 
+    // use random token from tokens array
     modifier useRandomToken(uint256 tokenIndexSeed) {
         currentTokenAddress = tokens[bound(tokenIndexSeed, 0, tokens.length - 1)];
         currentToken = TestnetERC20Token(currentTokenAddress);
         _;
     }
 
-    // helper modifier to use given token
+    // use base token as main token
+    // watch out, will fail if used with etherum
     modifier useBaseToken() {
         currentToken = TestnetERC20Token(getHyperchainBaseToken(currentChainId));
         currentTokenAddress = address(currentToken);
         _;
     }
 
+    // use erc20 token by getting randomly token and keep iterating,
+    // while the token is ETH
     modifier useERC20Token(uint256 tokenIndexSeed) {
         currentTokenAddress = tokens[bound(tokenIndexSeed, 0, tokens.length - 1)];
 
@@ -95,7 +111,7 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
         _;
     }
 
-    // generate MAX_USERS addresses and append it to testing adr
+    // generate MAX_USERS addresses and append it to users array
     function generateUserAddresses() internal {
         require(users.length == 0, "Addresses already generated");
 
@@ -105,6 +121,32 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
         }
     }
 
+    function commitBatchInfo(uint256 _chainId) internal {
+        //vm.warp(COMMIT_TIMESTAMP_NOT_OLDER + 1 + 1);
+
+        GettersFacet hyperchainGetters = GettersFacet(getHyperchainAddress(_chainId));
+
+        IExecutor.StoredBatchInfo memory batchZero;
+
+        batchZero.batchNumber = 0;
+        batchZero.timestamp = 0;
+        batchZero.numberOfLayer1Txs = 0;
+        batchZero.priorityOperationsHash = EMPTY_STRING_KECCAK;
+        batchZero.l2LogsTreeRoot = DEFAULT_L2_LOGS_TREE_ROOT_HASH;
+
+        // maybe replace it with something else
+        batchZero.batchHash = vm.parseBytes32("0x0000000000000000000000000000000000000000000000000000000000000000"); //genesis root hash
+        batchZero.indexRepeatedStorageChanges = uint64(0);
+        batchZero.commitment = vm.parseBytes32("0x0000000000000000000000000000000000000000000000000000000000000000");
+
+        bytes32 hashedZeroBatch = keccak256(abi.encode(batchZero));
+        assertEq(hyperchainGetters.storedBatchHash(0), hashedZeroBatch);
+
+        // TODO: consider creating blocks and then batches
+    }
+
+    // use mailbox interface to return exact amount to use as a gas,
+    // prevents from failing if mintValue < l2Value + required gas
     function getMinRequiredGasPriceForChain(
         uint256 _chainId,
         uint256 _gasPrice,
@@ -116,10 +158,12 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
         return chainMailBox.l2TransactionBaseCost(_gasPrice, _l2GasLimit, _l2GasPerPubdataByteLimit);
     }
 
+    // decodes data encoded with encodeCall, this is just to decode information received from logs
+    // to deposit into mock l2 contract
     function getDecodedDepositL2Calldata(
         bytes memory callData
     ) internal view returns (address l1Sender, address l2Receiver, address l1Token, uint256 amount, bytes memory b) {
-        // UnsafeBytes approach doesn't work, because abi is not deterministic in this approach i guess
+        // UnsafeBytes approach doesn't work, because abi is not deterministic
         bytes memory slicedData = new bytes(callData.length - 4);
 
         for (uint i = 4; i < callData.length; i++) {
@@ -132,10 +176,10 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
         );
     }
 
+    // handle event emited from logs and decodes it properly
     function handleRequestByMockL2Contract(NewPriorityRequest memory request) internal {
         address payable contractAddress = payable(address(uint160(uint256(request.transaction.to))));
         address someMockAddress = makeAddr("mocked");
-        // uint256 toSend; // = request.transaction.value; //ETH CASE
 
         address tokenAddress;
         address receiver;
@@ -145,7 +189,7 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
         uint256 requestLength = request.transaction.data.length;
         bytes memory temp;
 
-        if (requestLength == 612) {
+        if (requestLength > 96) {
             (l1Sender, receiver, tokenAddress, toSend, temp) = getDecodedDepositL2Calldata(request.transaction.data);
         } else {
             (tokenAddress, toSend, receiver) = abi.decode(request.transaction.data, (address, uint256, address));
@@ -177,14 +221,12 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
             balanceAfter = token.balanceOf(contractAddress);
         }
 
-        emit log_string("received");
-        emit log_uint(toSend);
-
         contractDeposits[contractAddress][tokenAddress] += toSend;
         contractDepositsSum[tokenAddress] += toSend;
         assertEq(balanceAfter, contractDeposits[contractAddress][tokenAddress]);
     }
 
+    // gets event from logs
     function getNewPriorityQueueFromLogs(Vm.Log[] memory logs) internal returns (NewPriorityRequest memory request) {
         for (uint256 i = 0; i < logs.length; i++) {
             Vm.Log memory log = logs[i];
@@ -201,11 +243,14 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
         }
     }
 
-    function depositNonEthToEthChain(uint256 l2Value, address tokenAddress) private useGivenToken(tokenAddress) {
-        uint256 gasPrice = 0.01 ether;
+    // deposits ERC20 token to the hyperchain where base token is ETH
+    // this funtion use requestL2TransactionTwoBridges function from shared bridge.
+    // tokenAddress should be any ERC20 token, excluding ETH
+    function depositERC20ToEthChain(uint256 l2Value, address tokenAddress) private useGivenToken(tokenAddress) {
+        uint256 gasPrice = 10000000;
         vm.txGasPrice(gasPrice);
 
-        uint256 l2GasLimit = 70000000; // reverts with 8
+        uint256 l2GasLimit = 1000000;
         uint256 minRequiredGas = getMinRequiredGasPriceForChain(
             currentChainId,
             gasPrice,
@@ -237,10 +282,6 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
         Vm.Log[] memory logs = vm.getRecordedLogs();
         NewPriorityRequest memory request = getNewPriorityQueueFromLogs(logs);
         assertNotEq(request.txHash, 0);
-
-        emit log_string("sent");
-        emit log_uint(l2Value);
-
         handleRequestByMockL2Contract(request);
         depositsUsers[currentUser][ETH_TOKEN_ADDRESS] += mintValue;
         depositsBridge[currentChainAddress][ETH_TOKEN_ADDRESS] += mintValue;
@@ -252,11 +293,121 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
         l2ValuesSum[currentTokenAddress] += l2Value;
     }
 
-    function depositEthToEthChain(uint256 l2Value) private {
-        uint256 gasPrice = 0.01 ether;
+    // deposits ETH token to chain where base token is some ERC20
+    // modifier prevents you from using some other token as base
+    function depositEthToERC20Chain(uint256 l2Value) private useBaseToken {
+        uint256 gasPrice = 10000000;
         vm.txGasPrice(gasPrice);
 
-        uint256 l2GasLimit = 70000000; // reverts with 8
+        uint256 l2GasLimit = 1000000; // reverts with 8
+        uint256 minRequiredGas = getMinRequiredGasPriceForChain(
+            currentChainId,
+            gasPrice,
+            l2GasLimit,
+            REQUIRED_L2_GAS_PRICE_PER_PUBDATA
+        );
+
+        vm.deal(currentUser, l2Value);
+        uint256 mintValue = minRequiredGas;
+        currentToken.mint(currentUser, mintValue);
+        assertEq(currentToken.balanceOf(currentUser), mintValue);
+        currentToken.approve(address(sharedBridge), mintValue);
+
+        bytes memory secondBridgeCallData = abi.encode(ETH_TOKEN_ADDRESS, uint256(0), chainContracts[currentChainId]);
+        L2TransactionRequestTwoBridgesOuter memory requestTx = createMockL2TransactionRequestTwoBridgesSecond(
+            currentChainId,
+            mintValue,
+            l2Value,
+            address(sharedBridge),
+            0, // L2 VALUE WHICH IS ALWAYS 0
+            l2GasLimit,
+            REQUIRED_L2_GAS_PRICE_PER_PUBDATA,
+            secondBridgeCallData
+        );
+
+        vm.recordLogs();
+
+        bytes32 resultantHash = bridgeHub.requestL2TransactionTwoBridges{value: l2Value}(requestTx);
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        NewPriorityRequest memory request = getNewPriorityQueueFromLogs(logs);
+        assertNotEq(request.txHash, 0);
+
+        handleRequestByMockL2Contract(request);
+        depositsUsers[currentUser][ETH_TOKEN_ADDRESS] += l2Value;
+        depositsBridge[currentChainAddress][ETH_TOKEN_ADDRESS] += l2Value;
+        tokenSumDeposit[ETH_TOKEN_ADDRESS] += l2Value;
+        l2ValuesSum[ETH_TOKEN_ADDRESS] += l2Value;
+
+        depositsUsers[currentUser][currentTokenAddress] += mintValue;
+        depositsBridge[currentChainAddress][currentTokenAddress] += mintValue;
+        tokenSumDeposit[currentTokenAddress] += mintValue;
+    }
+
+    // deposits ERC20 to token with base being also ERC20
+    // there are no modifiers so watch out, baseTokenAddress should be base of hyperchain
+    // currentToken should be different from base
+    function depositERC20ToERC20Chain(uint256 l2Value, address baseTokenAddress) private {
+        uint256 gasPrice = 10000000;
+        vm.txGasPrice(gasPrice);
+
+        uint256 l2GasLimit = 1000000; // reverts with 8
+        uint256 minRequiredGas = getMinRequiredGasPriceForChain(
+            currentChainId,
+            gasPrice,
+            l2GasLimit,
+            REQUIRED_L2_GAS_PRICE_PER_PUBDATA
+        );
+
+        uint256 mintValue = minRequiredGas;
+
+        TestnetERC20Token baseToken = TestnetERC20Token(baseTokenAddress);
+        baseToken.mint(currentUser, mintValue);
+        assertEq(baseToken.balanceOf(currentUser), mintValue);
+        baseToken.approve(address(sharedBridge), mintValue);
+
+        currentToken.mint(currentUser, l2Value);
+        assertEq(currentToken.balanceOf(currentUser), l2Value);
+        currentToken.approve(address(sharedBridge), l2Value);
+
+        bytes memory secondBridgeCallData = abi.encode(currentTokenAddress, l2Value, chainContracts[currentChainId]);
+        L2TransactionRequestTwoBridgesOuter memory requestTx = createMockL2TransactionRequestTwoBridgesSecond(
+            currentChainId,
+            mintValue,
+            0,
+            address(sharedBridge),
+            0, // L2 VALUE WHICH IS ALWAYS 0
+            l2GasLimit,
+            REQUIRED_L2_GAS_PRICE_PER_PUBDATA,
+            secondBridgeCallData
+        );
+
+        vm.recordLogs();
+        bytes32 resultantHash = bridgeHub.requestL2TransactionTwoBridges(requestTx);
+
+        // get request
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        NewPriorityRequest memory request = getNewPriorityQueueFromLogs(logs);
+        assertNotEq(request.txHash, 0);
+
+        handleRequestByMockL2Contract(request);
+
+        depositsUsers[currentUser][baseTokenAddress] += mintValue;
+        depositsBridge[currentChainAddress][baseTokenAddress] += mintValue;
+        tokenSumDeposit[baseTokenAddress] += mintValue;
+
+        depositsUsers[currentUser][currentTokenAddress] += l2Value;
+        depositsBridge[currentChainAddress][currentTokenAddress] += l2Value;
+        tokenSumDeposit[currentTokenAddress] += l2Value;
+        l2ValuesSum[currentTokenAddress] += l2Value;
+    }
+
+    // deposits ETH to hyperchain where base is ETH
+    function depositEthBase(uint256 l2Value) private {
+        uint256 gasPrice = 10000000;
+        vm.txGasPrice(gasPrice);
+
+        uint256 l2GasLimit = 1000000; // reverts with 8
         uint256 minRequiredGas = getMinRequiredGasPriceForChain(
             currentChainId,
             gasPrice,
@@ -294,13 +445,12 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
     }
 
     // deposits base ERC20 token to the bridge
-    // uses token provided as a input
     function depositERC20Base(uint256 l2Value) private useBaseToken {
-        uint256 gasPrice = 0.01 ether;
+        uint256 gasPrice = 10000000;
         vm.txGasPrice(gasPrice);
         vm.deal(currentUser, gasPrice);
 
-        uint256 l2GasLimit = 70000000; // reverts with 8
+        uint256 l2GasLimit = 1000000;
         uint256 minRequiredGas = getMinRequiredGasPriceForChain(
             currentChainId,
             gasPrice,
@@ -339,35 +489,19 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
         l2ValuesSum[currentTokenAddress] += l2Value;
     }
 
-    function depositEthToEthBridgeSuccess(
+    function depositEthToBridgeSuccess(
         uint256 userIndexSeed,
         uint256 chainIndexSeed,
         uint256 l2Value
-    ) public virtual useUser(userIndexSeed) useHyperchain(chainIndexSeed) {
-        if (getHyperchainBaseToken(currentChainId) == ETH_TOKEN_ADDRESS) {
-            depositEthToEthChain(l2Value);
+    ) public virtual useUser(userIndexSeed) useHyperchain(chainIndexSeed) useBaseToken {
+        if (currentTokenAddress == ETH_TOKEN_ADDRESS) {
+            depositEthBase(l2Value);
         } else {
-            // idk
-            //depositEthToNonEthChain(mintValue, l2Value);
+            depositEthToERC20Chain(l2Value);
         }
     }
 
-    function depositEthToEthBridgeFails(
-        uint256 userIndexSeed,
-        uint256 chainIndexSeed,
-        uint256 l2Value
-    ) public virtual useUser(userIndexSeed) useHyperchain(chainIndexSeed) {
-        if (getHyperchainBaseToken(currentChainId) == ETH_TOKEN_ADDRESS) {
-            // idk
-            //vm.expectRevert("Bridgehub: msg.value mismatch 1");
-            //depositEthToNonEthChain(mintValue, l2Value);
-        } else {
-            vm.expectRevert("Bridgehub: non-eth bridge with msg.value");
-            depositEthToEthChain(l2Value);
-        }
-    }
-
-    function depositERC20TokenToBridgeSuccess(
+    function depositERC20ToBridgeSuccess(
         uint256 userIndexSeed,
         uint256 chainIndexSeed,
         uint256 tokenIndexSeed,
@@ -376,12 +510,12 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
         address chainBaseToken = getHyperchainBaseToken(currentChainId);
 
         if (chainBaseToken == ETH_TOKEN_ADDRESS) {
-            depositNonEthToEthChain(l2Value, currentTokenAddress);
+            depositERC20ToEthChain(l2Value, currentTokenAddress);
         } else {
             if (currentTokenAddress == chainBaseToken) {
                 depositERC20Base(l2Value);
             } else {
-                // depositNonEthToNonEthChain(l2Value, currentTokenAddress);
+                depositERC20ToERC20Chain(l2Value, chainBaseToken);
             }
         }
     }
@@ -413,14 +547,7 @@ contract BoundedBridgeHubInvariantTests is BridgeHubInvariantTests {
         uint64 MAX = 2 ** 64 - 1;
         uint256 l2Value = bound(l2Value, 0.1 ether, MAX);
 
-        super.depositEthToEthBridgeSuccess(userIndexSeed, chainIndexSeed, l2Value);
-    }
-
-    function depositEthFail(uint256 userIndexSeed, uint256 chainIndexSeed, uint256 l2Value) public {
-        uint64 MAX = 2 ** 64 - 1;
-        uint256 l2Value = bound(l2Value, 0.1 ether, MAX);
-
-        super.depositEthToEthBridgeFails(userIndexSeed, chainIndexSeed, l2Value);
+        super.depositEthToBridgeSuccess(userIndexSeed, chainIndexSeed, l2Value);
     }
 
     function depositERC20Success(
@@ -432,11 +559,11 @@ contract BoundedBridgeHubInvariantTests is BridgeHubInvariantTests {
         uint64 MAX = 2 ** 64 - 1;
         uint256 l2Value = bound(l2Value, 0.1 ether, MAX);
 
-        super.depositERC20TokenToBridgeSuccess(userIndexSeed, chainIndexSeed, tokenIndexSeed, l2Value);
+        super.depositERC20ToBridgeSuccess(userIndexSeed, chainIndexSeed, tokenIndexSeed, l2Value);
     }
 }
 
-contract InvariantTester is Test {
+contract InvariantTesterHyperchains is Test {
     BoundedBridgeHubInvariantTests tests;
 
     function setUp() public {
@@ -445,9 +572,8 @@ contract InvariantTester is Test {
 
         FuzzSelector memory selector = FuzzSelector({addr: address(tests), selectors: new bytes4[](2)});
 
-        selector.selectors[0] = BoundedBridgeHubInvariantTests.depositERC20Success.selector;
-        selector.selectors[1] = BoundedBridgeHubInvariantTests.depositEthSuccess.selector;
-        // selector.selectors[1] = BoundedBridgeHubInvariantTests.depositERC20Success.selector;
+        selector.selectors[0] = BoundedBridgeHubInvariantTests.depositEthSuccess.selector;
+        selector.selectors[1] = BoundedBridgeHubInvariantTests.depositERC20Success.selector;
 
         targetContract(address(tests));
         targetSelector(selector);
@@ -476,7 +602,7 @@ contract InvariantTester is Test {
 
     // check if sum of ETH part which is send to L2 contract, registered by this test suite
     // is equals actual sum of balances of l2 contracts (which are mocked, but read events from logs)
-    /// forge-config: default.invariant.fail-on-revert = false
+    /// forge-config: default.invariant.fail-on-revert = true
     function invariant_ETHbalaceOnContractsDeposited() public {
         uint256 sum = 0;
 
@@ -490,7 +616,6 @@ contract InvariantTester is Test {
 
         assertEq(tests.l2ValuesSum(ETH_TOKEN_ADDRESS), sum);
         assertEq(tests.contractDepositsSum(ETH_TOKEN_ADDRESS), sum);
-        assertEq(tests.l2ValuesSum(ETH_TOKEN_ADDRESS), tests.contractDepositsSum(ETH_TOKEN_ADDRESS));
     }
 
     // check if sum of currentToken part which is send to L2 contract, registered by this test suite
@@ -508,12 +633,12 @@ contract InvariantTester is Test {
             TestnetERC20Token token = TestnetERC20Token(currentTokenAddress);
             address l2Contract = tests.chainContracts(tests.hyperchainIds(i));
             uint256 balance = token.balanceOf(l2Contract);
-            assertEq(tests.contractDeposits(l2Contract, ETH_TOKEN_ADDRESS), balance);
+            assertEq(tests.contractDeposits(l2Contract, currentTokenAddress), balance);
             sum += balance;
         }
 
-        assertEq(tests.l2ValuesSum(currentTokenAddress), sum);
         assertEq(tests.contractDepositsSum(currentTokenAddress), sum);
-        assertEq(tests.l2ValuesSum(currentTokenAddress), tests.contractDepositsSum(currentTokenAddress));
+        assertEq(tests.l2ValuesSum(currentTokenAddress), sum);
     }
 }
+

--- a/l1-contracts/test/foundry/integration/BridgeHubInvariantTests.t.sol
+++ b/l1-contracts/test/foundry/integration/BridgeHubInvariantTests.t.sol
@@ -16,7 +16,7 @@ import {REQUIRED_L2_GAS_PRICE_PER_PUBDATA} from "contracts/common/Config.sol";
 import {Vm} from "forge-std/Vm.sol";
 import {L2CanonicalTransaction} from "contracts/common/Messaging.sol";
 
-contract BaseIntegrationTests is L1ContractDeployer, HyperchainDeployer, TokenDeployer, L2TxMocker {
+contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, TokenDeployer, L2TxMocker {
     uint constant TEST_USERS_COUNT = 10;
 
     bytes32 constant NEW_PRIORITY_REQUEST_HASH =
@@ -295,7 +295,7 @@ contract BaseIntegrationTests is L1ContractDeployer, HyperchainDeployer, TokenDe
     }
 }
 
-contract BoundedBaseIntegrationTests is BaseIntegrationTests {
+contract BoundedBridgeHubInvariantTests is BridgeHubInvariantTests {
     function depositEthSuccess(uint256 userIndexSeed, uint256 chainIndexSeed, uint256 l2Value) public {
         uint64 MAX = 2 ** 64 - 1;
         uint256 l2Value = bound(l2Value, 0.1 ether, MAX);
@@ -324,17 +324,17 @@ contract BoundedBaseIntegrationTests is BaseIntegrationTests {
 }
 
 contract InvariantTester is Test {
-    BoundedBaseIntegrationTests tests;
+    BoundedBridgeHubInvariantTests tests;
 
     function setUp() public {
-        tests = new BoundedBaseIntegrationTests();
+        tests = new BoundedBridgeHubInvariantTests();
         tests.prepare();
 
         FuzzSelector memory selector = FuzzSelector({addr: address(tests), selectors: new bytes4[](2)});
 
-        selector.selectors[0] = BoundedBaseIntegrationTests.depositEthSuccess.selector;
-        // selector.selectors[1] = BoundedBaseIntegrationTests.depositEthFail.selector;
-        selector.selectors[1] = BoundedBaseIntegrationTests.depositERC20Success.selector;
+        selector.selectors[0] = BoundedBridgeHubInvariantTests.depositEthSuccess.selector;
+        // selector.selectors[1] = BoundedBridgeHubInvariantTests.depositEthFail.selector;
+        selector.selectors[1] = BoundedBridgeHubInvariantTests.depositERC20Success.selector;
 
         targetContract(address(tests));
         targetSelector(selector);

--- a/l1-contracts/test/foundry/integration/BridgeHubInvariantTests.t.sol
+++ b/l1-contracts/test/foundry/integration/BridgeHubInvariantTests.t.sol
@@ -7,33 +7,32 @@ import {MailboxFacet} from "contracts/state-transition/chain-deps/facets/Mailbox
 import {GettersFacet} from "contracts/state-transition/chain-deps/facets/Getters.sol";
 import {IMailbox} from "contracts/state-transition/chain-interfaces/IMailbox.sol";
 import {IExecutor} from "contracts/state-transition/chain-interfaces/IExecutor.sol";
-import {IGetters} from "contracts/state-transition/chain-interfaces/IGetters.sol";
-
-import {IStateTransitionManager} from "contracts/state-transition/IStateTransitionManager.sol";
-
 import {L1ContractDeployer} from "./_SharedL1ContractDeployer.t.sol";
 import {TokenDeployer} from "./_SharedTokenDeployer.t.sol";
 import {HyperchainDeployer} from "./_SharedHyperchainDeployer.t.sol";
 import {L2TxMocker} from "./_SharedL2TxMocker.t.sol";
 import {Test} from "forge-std/Test.sol";
 import {ETH_TOKEN_ADDRESS} from "contracts/common/Config.sol";
-import {REQUIRED_L2_GAS_PRICE_PER_PUBDATA, COMMIT_TIMESTAMP_NOT_OLDER, DEFAULT_L2_LOGS_TREE_ROOT_HASH, EMPTY_STRING_KECCAK} from "contracts/common/Config.sol";
+import {REQUIRED_L2_GAS_PRICE_PER_PUBDATA, DEFAULT_L2_LOGS_TREE_ROOT_HASH, EMPTY_STRING_KECCAK} from "contracts/common/Config.sol";
 import {Vm} from "forge-std/Vm.sol";
 import {L2CanonicalTransaction} from "contracts/common/Messaging.sol";
-import {IL2Bridge} from "contracts/bridge/interfaces/IL2Bridge.sol";
 import {L2Message} from "contracts/common/Messaging.sol";
 import {IBridgehub} from "contracts/bridgehub/IBridgehub.sol";
 import {L2_BASE_TOKEN_SYSTEM_CONTRACT_ADDR} from "contracts/common/L2ContractAddresses.sol";
-
 import {IL1ERC20Bridge} from "contracts/bridge/interfaces/IL1ERC20Bridge.sol";
 
 contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, TokenDeployer, L2TxMocker {
-    uint constant TEST_USERS_COUNT = 10;
+    uint256 constant TEST_USERS_COUNT = 10;
 
     bytes32 constant NEW_PRIORITY_REQUEST_HASH =
         keccak256(
             "NewPriorityRequest(uint256,bytes32,uint64,(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,uint256[],bytes,bytes),bytes[])"
         );
+
+    enum RequestType {
+        DIRECT,
+        TWO_BRIDGES
+    }
 
     struct NewPriorityRequest {
         uint256 txId;
@@ -121,7 +120,7 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
     function generateUserAddresses() internal {
         require(users.length == 0, "Addresses already generated");
 
-        for (uint i = 0; i < TEST_USERS_COUNT; i++) {
+        for (uint256 i = 0; i < TEST_USERS_COUNT; i++) {
             address newAddress = makeAddr(string(abi.encode("account", i)));
             users.push(newAddress);
         }
@@ -141,8 +140,6 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
         batchZero.numberOfLayer1Txs = 0;
         batchZero.priorityOperationsHash = EMPTY_STRING_KECCAK;
         batchZero.l2LogsTreeRoot = DEFAULT_L2_LOGS_TREE_ROOT_HASH;
-
-        // maybe replace it with something else
         batchZero.batchHash = vm.parseBytes32("0x0000000000000000000000000000000000000000000000000000000000000000"); //genesis root hash
         batchZero.indexRepeatedStorageChanges = uint64(0);
         batchZero.commitment = vm.parseBytes32("0x0000000000000000000000000000000000000000000000000000000000000000");
@@ -172,7 +169,7 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
         // UnsafeBytes approach doesn't work, because abi is not deterministic
         bytes memory slicedData = new bytes(callData.length - 4);
 
-        for (uint i = 4; i < callData.length; i++) {
+        for (uint256 i = 4; i < callData.length; i++) {
             slicedData[i - 4] = callData[i];
         }
 
@@ -183,7 +180,7 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
     }
 
     // handle event emited from, just to ensure proper decoding to set mock contract balance
-    function handleRequestByMockL2Contract(NewPriorityRequest memory request) internal {
+    function handleRequestByMockL2Contract(NewPriorityRequest memory request, RequestType requestType) internal {
         address contractAddress = address(uint160(uint256(request.transaction.to)));
 
         address tokenAddress;
@@ -195,7 +192,7 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
 
         uint256 requestLength = request.transaction.data.length;
 
-        if (requestLength > 96) {
+        if (requestType == RequestType.TWO_BRIDGES) {
             (l1Sender, receiver, tokenAddress, toSend, temp) = getDecodedDepositL2Calldata(request.transaction.data);
         } else {
             (tokenAddress, toSend, receiver) = abi.decode(request.transaction.data, (address, uint256, address));
@@ -259,23 +256,25 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
         currentToken.approve(address(sharedBridge), l2Value);
 
         bytes memory secondBridgeCallData = abi.encode(currentTokenAddress, l2Value, chainContracts[currentChainId]);
-        L2TransactionRequestTwoBridgesOuter memory requestTx = createMockL2TransactionRequestTwoBridgesSecond(
-            currentChainId,
-            mintValue,
-            0,
-            address(sharedBridge),
-            0, // L2 VALUE WHICH IS ALWAYS 0
-            l2GasLimit,
-            REQUIRED_L2_GAS_PRICE_PER_PUBDATA,
-            secondBridgeCallData
-        );
+        L2TransactionRequestTwoBridgesOuter memory requestTx = createL2TransactionRequestTwoBridges({
+            _chainId: currentChainId,
+            _mintValue: mintValue,
+            _secondBridgeValue: 0,
+            _secondBridgeAddress: address(sharedBridge),
+            _l2Value: 0,
+            _l2GasLimit: l2GasLimit,
+            _l2GasPerPubdataByteLimit: REQUIRED_L2_GAS_PRICE_PER_PUBDATA,
+            _secondBridgeCalldata: secondBridgeCallData
+        });
 
         vm.recordLogs();
-        bytes32 resultantHash = bridgeHub.requestL2TransactionTwoBridges{value: mintValue}(requestTx);
+        bytes32 _resultantHash = bridgeHub.requestL2TransactionTwoBridges{value: mintValue}(requestTx);
         Vm.Log[] memory logs = vm.getRecordedLogs();
         NewPriorityRequest memory request = getNewPriorityQueueFromLogs(logs);
+
         assertNotEq(request.txHash, 0);
-        handleRequestByMockL2Contract(request);
+        handleRequestByMockL2Contract(request, RequestType.TWO_BRIDGES);
+
         depositsUsers[currentUser][ETH_TOKEN_ADDRESS] += mintValue;
         depositsBridge[currentChainAddress][ETH_TOKEN_ADDRESS] += mintValue;
         tokenSumDeposit[ETH_TOKEN_ADDRESS] += mintValue;
@@ -292,7 +291,7 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
         uint256 gasPrice = 10000000;
         vm.txGasPrice(gasPrice);
 
-        uint256 l2GasLimit = 1000000; // reverts with 8
+        uint256 l2GasLimit = 1000000; 
         uint256 minRequiredGas = getMinRequiredGasPriceForChain(
             currentChainId,
             gasPrice,
@@ -306,26 +305,25 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
         currentToken.approve(address(sharedBridge), mintValue);
 
         bytes memory secondBridgeCallData = abi.encode(ETH_TOKEN_ADDRESS, uint256(0), chainContracts[currentChainId]);
-        L2TransactionRequestTwoBridgesOuter memory requestTx = createMockL2TransactionRequestTwoBridgesSecond(
-            currentChainId,
-            mintValue,
-            l2Value,
-            address(sharedBridge),
-            0, // L2 VALUE WHICH IS ALWAYS 0
-            l2GasLimit,
-            REQUIRED_L2_GAS_PRICE_PER_PUBDATA,
-            secondBridgeCallData
-        );
+        L2TransactionRequestTwoBridgesOuter memory requestTx = createL2TransactionRequestTwoBridges({
+            _chainId: currentChainId,
+            _mintValue: mintValue,
+            _secondBridgeValue: l2Value,
+            _secondBridgeAddress: address(sharedBridge),
+            _l2Value: 0,
+            _l2GasLimit: l2GasLimit,
+            _l2GasPerPubdataByteLimit: REQUIRED_L2_GAS_PRICE_PER_PUBDATA,
+            _secondBridgeCalldata: secondBridgeCallData
+        });
 
         vm.recordLogs();
-
-        bytes32 resultantHash = bridgeHub.requestL2TransactionTwoBridges{value: l2Value}(requestTx);
-
+        bytes32 _resultantHash = bridgeHub.requestL2TransactionTwoBridges{value: l2Value}(requestTx);
         Vm.Log[] memory logs = vm.getRecordedLogs();
         NewPriorityRequest memory request = getNewPriorityQueueFromLogs(logs);
         assertNotEq(request.txHash, 0);
 
-        handleRequestByMockL2Contract(request);
+        handleRequestByMockL2Contract(request, RequestType.TWO_BRIDGES);
+
         depositsUsers[currentUser][ETH_TOKEN_ADDRESS] += l2Value;
         depositsBridge[currentChainAddress][ETH_TOKEN_ADDRESS] += l2Value;
         tokenSumDeposit[ETH_TOKEN_ADDRESS] += l2Value;
@@ -343,7 +341,7 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
         uint256 gasPrice = 10000000;
         vm.txGasPrice(gasPrice);
 
-        uint256 l2GasLimit = 1000000; // reverts with 8
+        uint256 l2GasLimit = 1000000; 
         uint256 minRequiredGas = getMinRequiredGasPriceForChain(
             currentChainId,
             gasPrice,
@@ -361,26 +359,24 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
         currentToken.approve(address(sharedBridge), l2Value);
 
         bytes memory secondBridgeCallData = abi.encode(currentTokenAddress, l2Value, chainContracts[currentChainId]);
-        L2TransactionRequestTwoBridgesOuter memory requestTx = createMockL2TransactionRequestTwoBridgesSecond(
-            currentChainId,
-            mintValue,
-            0,
-            address(sharedBridge),
-            0, // L2 VALUE WHICH IS ALWAYS 0
-            l2GasLimit,
-            REQUIRED_L2_GAS_PRICE_PER_PUBDATA,
-            secondBridgeCallData
-        );
+        L2TransactionRequestTwoBridgesOuter memory requestTx = createL2TransactionRequestTwoBridges({
+            _chainId: currentChainId,
+            _mintValue: mintValue,
+            _secondBridgeValue: 0,
+            _secondBridgeAddress: address(sharedBridge),
+            _l2Value: 0,
+            _l2GasLimit: l2GasLimit,
+            _l2GasPerPubdataByteLimit: REQUIRED_L2_GAS_PRICE_PER_PUBDATA,
+            _secondBridgeCalldata: secondBridgeCallData
+        });
 
         vm.recordLogs();
-        bytes32 resultantHash = bridgeHub.requestL2TransactionTwoBridges(requestTx);
-
-        // get request
+        bytes32 _resultantHash = bridgeHub.requestL2TransactionTwoBridges(requestTx);
         Vm.Log[] memory logs = vm.getRecordedLogs();
         NewPriorityRequest memory request = getNewPriorityQueueFromLogs(logs);
         assertNotEq(request.txHash, 0);
 
-        handleRequestByMockL2Contract(request);
+        handleRequestByMockL2Contract(request, RequestType.TWO_BRIDGES);
 
         depositsUsers[currentUser][baseTokenAddress] += mintValue;
         depositsBridge[currentChainAddress][baseTokenAddress] += mintValue;
@@ -409,24 +405,23 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
         vm.deal(currentUser, mintValue);
 
         bytes memory callData = abi.encode(currentTokenAddress, l2Value, chainContracts[currentChainId]);
-        L2TransactionRequestDirect memory txRequest = createL2TransitionRequestDirectSecond(
-            currentChainId,
-            mintValue,
-            l2Value,
-            l2GasLimit,
-            REQUIRED_L2_GAS_PRICE_PER_PUBDATA,
-            ETH_TOKEN_ADDRESS,
-            callData
-        );
+        L2TransactionRequestDirect memory txRequest = createL2TransactionRequestDirect({
+            _chainId: currentChainId,
+            _mintValue: mintValue,
+            _l2Value: l2Value,
+            _l2GasLimit: l2GasLimit,
+            _l2GasPerPubdataByteLimit: REQUIRED_L2_GAS_PRICE_PER_PUBDATA,
+            _l2CallData: callData
+        });
 
         vm.recordLogs();
-        bytes32 resultantHash = bridgeHub.requestL2TransactionDirect{value: mintValue}(txRequest);
+        bytes32 _resultantHash = bridgeHub.requestL2TransactionDirect{value: mintValue}(txRequest);
         Vm.Log[] memory logs = vm.getRecordedLogs();
 
         NewPriorityRequest memory request = getNewPriorityQueueFromLogs(logs);
         assertNotEq(request.txHash, 0);
 
-        handleRequestByMockL2Contract(request);
+        handleRequestByMockL2Contract(request, RequestType.DIRECT);
 
         depositsUsers[currentUser][ETH_TOKEN_ADDRESS] += mintValue;
         depositsBridge[currentChainAddress][ETH_TOKEN_ADDRESS] += mintValue;
@@ -453,24 +448,23 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
         currentToken.approve(address(sharedBridge), mintValue);
 
         bytes memory callData = abi.encode(currentTokenAddress, l2Value, chainContracts[currentChainId]);
-        L2TransactionRequestDirect memory txRequest = createL2TransitionRequestDirectSecond(
-            currentChainId,
-            mintValue,
-            l2Value,
-            l2GasLimit,
-            REQUIRED_L2_GAS_PRICE_PER_PUBDATA,
-            currentTokenAddress,
-            callData
-        );
+        L2TransactionRequestDirect memory txRequest = createL2TransactionRequestDirect({
+            _chainId: currentChainId,
+            _mintValue: mintValue,
+            _l2Value: l2Value,
+            _l2GasLimit: l2GasLimit,
+            _l2GasPerPubdataByteLimit: REQUIRED_L2_GAS_PRICE_PER_PUBDATA,
+            _l2CallData: callData
+        });
 
         vm.recordLogs();
-        bytes32 resultantHash = bridgeHub.requestL2TransactionDirect(txRequest);
+        bytes32 _resultantHash = bridgeHub.requestL2TransactionDirect(txRequest);
         Vm.Log[] memory logs = vm.getRecordedLogs();
 
         NewPriorityRequest memory request = getNewPriorityQueueFromLogs(logs);
         assertNotEq(request.txHash, 0);
 
-        handleRequestByMockL2Contract(request);
+        handleRequestByMockL2Contract(request, RequestType.DIRECT);
 
         depositsUsers[currentUser][currentTokenAddress] += mintValue;
         depositsBridge[currentChainAddress][currentTokenAddress] += mintValue;
@@ -630,7 +624,6 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
     function withdrawSuccess(
         uint256 userIndexSeed,
         uint256 chainIndexSeed,
-        uint256 tokenIndexSeed,
         uint256 amountToWithdraw
     ) public virtual useUser(userIndexSeed) useHyperchain(chainIndexSeed) {
         address token = getHyperchainBaseToken(currentChainId);
@@ -690,7 +683,6 @@ contract BoundedBridgeHubInvariantTests is BridgeHubInvariantTests {
 
     function withdrawERC20Success(
         uint256 userIndexSeed,
-        uint256 tokenIndexSeed,
         uint256 chainIndexSeed,
         uint256 amountToWithdraw
     ) public {
@@ -698,7 +690,7 @@ contract BoundedBridgeHubInvariantTests is BridgeHubInvariantTests {
         uint256 amountToWithdraw = bound(amountToWithdraw, 0.1 ether, MAX);
 
         emit log_string("WITHDRAW ERC20");
-        super.withdrawSuccess(userIndexSeed, tokenIndexSeed, tokenIndexSeed, amountToWithdraw);
+        super.withdrawSuccess(userIndexSeed, chainIndexSeed, amountToWithdraw);
     }
 }
 

--- a/l1-contracts/test/foundry/integration/BridgeHubInvariantTests.t.sol
+++ b/l1-contracts/test/foundry/integration/BridgeHubInvariantTests.t.sol
@@ -126,7 +126,7 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
         }
     }
 
-    // TODO: consider what should be actually commited, do we need to simulate operator:
+    // TODO: consider what should be actually committed, do we need to simulate operator:
     // blocks -> batches -> commits or just mock it.
     function commitBatchInfo(uint256 _chainId) internal {
         //vm.warp(COMMIT_TIMESTAMP_NOT_OLDER + 1 + 1);
@@ -179,7 +179,7 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
         );
     }
 
-    // handle event emited from, just to ensure proper decoding to set mock contract balance
+    // handle event emitted from logs, just to ensure proper decoding to set mock contract balance
     function handleRequestByMockL2Contract(NewPriorityRequest memory request, RequestType requestType) internal {
         address contractAddress = address(uint160(uint256(request.transaction.to)));
 
@@ -189,8 +189,6 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
         address l1Sender;
         uint256 balanceAfter;
         bytes memory temp;
-
-        uint256 requestLength = request.transaction.data.length;
 
         if (requestType == RequestType.TWO_BRIDGES) {
             (l1Sender, receiver, tokenAddress, toSend, temp) = getDecodedDepositL2Calldata(request.transaction.data);
@@ -235,7 +233,7 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
     }
 
     // deposits ERC20 token to the hyperchain where base token is ETH
-    // this funtion use requestL2TransactionTwoBridges function from shared bridge.
+    // this function use requestL2TransactionTwoBridges function from shared bridge.
     // tokenAddress should be any ERC20 token, excluding ETH
     function depositERC20ToEthChain(uint256 l2Value, address tokenAddress) private useGivenToken(tokenAddress) {
         uint256 gasPrice = 10000000;
@@ -268,11 +266,12 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
         });
 
         vm.recordLogs();
-        bytes32 _resultantHash = bridgeHub.requestL2TransactionTwoBridges{value: mintValue}(requestTx);
+        bytes32 resultantHash = bridgeHub.requestL2TransactionTwoBridges{value: mintValue}(requestTx);
         Vm.Log[] memory logs = vm.getRecordedLogs();
         NewPriorityRequest memory request = getNewPriorityQueueFromLogs(logs);
 
-        assertNotEq(request.txHash, 0);
+        assertNotEq(resultantHash, bytes32(0));
+        assertNotEq(request.txHash, bytes32(0));
         handleRequestByMockL2Contract(request, RequestType.TWO_BRIDGES);
 
         depositsUsers[currentUser][ETH_TOKEN_ADDRESS] += mintValue;
@@ -291,7 +290,7 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
         uint256 gasPrice = 10000000;
         vm.txGasPrice(gasPrice);
 
-        uint256 l2GasLimit = 1000000; 
+        uint256 l2GasLimit = 1000000;
         uint256 minRequiredGas = getMinRequiredGasPriceForChain(
             currentChainId,
             gasPrice,
@@ -317,11 +316,12 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
         });
 
         vm.recordLogs();
-        bytes32 _resultantHash = bridgeHub.requestL2TransactionTwoBridges{value: l2Value}(requestTx);
+        bytes32 resultantHash = bridgeHub.requestL2TransactionTwoBridges{value: l2Value}(requestTx);
         Vm.Log[] memory logs = vm.getRecordedLogs();
         NewPriorityRequest memory request = getNewPriorityQueueFromLogs(logs);
-        assertNotEq(request.txHash, 0);
 
+        assertNotEq(resultantHash, bytes32(0));
+        assertNotEq(request.txHash, bytes32(0));
         handleRequestByMockL2Contract(request, RequestType.TWO_BRIDGES);
 
         depositsUsers[currentUser][ETH_TOKEN_ADDRESS] += l2Value;
@@ -341,7 +341,7 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
         uint256 gasPrice = 10000000;
         vm.txGasPrice(gasPrice);
 
-        uint256 l2GasLimit = 1000000; 
+        uint256 l2GasLimit = 1000000;
         uint256 minRequiredGas = getMinRequiredGasPriceForChain(
             currentChainId,
             gasPrice,
@@ -371,11 +371,12 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
         });
 
         vm.recordLogs();
-        bytes32 _resultantHash = bridgeHub.requestL2TransactionTwoBridges(requestTx);
+        bytes32 resultantHash = bridgeHub.requestL2TransactionTwoBridges(requestTx);
         Vm.Log[] memory logs = vm.getRecordedLogs();
         NewPriorityRequest memory request = getNewPriorityQueueFromLogs(logs);
-        assertNotEq(request.txHash, 0);
 
+        assertNotEq(resultantHash, bytes32(0));
+        assertNotEq(request.txHash, bytes32(0));
         handleRequestByMockL2Contract(request, RequestType.TWO_BRIDGES);
 
         depositsUsers[currentUser][baseTokenAddress] += mintValue;
@@ -415,12 +416,13 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
         });
 
         vm.recordLogs();
-        bytes32 _resultantHash = bridgeHub.requestL2TransactionDirect{value: mintValue}(txRequest);
+        bytes32 resultantHash = bridgeHub.requestL2TransactionDirect{value: mintValue}(txRequest);
         Vm.Log[] memory logs = vm.getRecordedLogs();
 
         NewPriorityRequest memory request = getNewPriorityQueueFromLogs(logs);
-        assertNotEq(request.txHash, 0);
 
+        assertNotEq(resultantHash, bytes32(0));
+        assertNotEq(request.txHash, bytes32(0));
         handleRequestByMockL2Contract(request, RequestType.DIRECT);
 
         depositsUsers[currentUser][ETH_TOKEN_ADDRESS] += mintValue;
@@ -458,12 +460,13 @@ contract BridgeHubInvariantTests is L1ContractDeployer, HyperchainDeployer, Toke
         });
 
         vm.recordLogs();
-        bytes32 _resultantHash = bridgeHub.requestL2TransactionDirect(txRequest);
+        bytes32 resultantHash = bridgeHub.requestL2TransactionDirect(txRequest);
         Vm.Log[] memory logs = vm.getRecordedLogs();
 
         NewPriorityRequest memory request = getNewPriorityQueueFromLogs(logs);
-        assertNotEq(request.txHash, 0);
 
+        assertNotEq(resultantHash, bytes32(0));
+        assertNotEq(request.txHash, bytes32(0));
         handleRequestByMockL2Contract(request, RequestType.DIRECT);
 
         depositsUsers[currentUser][currentTokenAddress] += mintValue;
@@ -681,11 +684,7 @@ contract BoundedBridgeHubInvariantTests is BridgeHubInvariantTests {
         super.depositERC20ToBridgeSuccess(userIndexSeed, chainIndexSeed, tokenIndexSeed, l2Value);
     }
 
-    function withdrawERC20Success(
-        uint256 userIndexSeed,
-        uint256 chainIndexSeed,
-        uint256 amountToWithdraw
-    ) public {
+    function withdrawERC20Success(uint256 userIndexSeed, uint256 chainIndexSeed, uint256 amountToWithdraw) public {
         uint64 MAX = (2 ** 32 - 1) + 0.1 ether;
         uint256 amountToWithdraw = bound(amountToWithdraw, 0.1 ether, MAX);
 

--- a/l1-contracts/test/foundry/integration/_SharedHyperchainDeployer.t.sol
+++ b/l1-contracts/test/foundry/integration/_SharedHyperchainDeployer.t.sol
@@ -16,7 +16,7 @@ contract HyperchainDeployer is L1ContractDeployer {
 
     uint256 currentHyperChainId = 10;
     uint256 eraHyperchainId = 9;
-    uint256[] hyperchainIds;
+    uint256[] public hyperchainIds;
 
     function deployHyperchains() internal {
         deployScript = new RegisterHyperchainsScript();

--- a/l1-contracts/test/foundry/integration/_SharedL1ContractDeployer.t.sol
+++ b/l1-contracts/test/foundry/integration/_SharedL1ContractDeployer.t.sol
@@ -16,8 +16,7 @@ contract L1ContractDeployer is Test {
     Bridgehub bridgeHub;
 
     address public sharedBridgeProxyAddress;
-    L1SharedBridge public sharedBridge; 
-
+    L1SharedBridge public sharedBridge;
 
     function deployL1Contracts() internal {
         DeployL1Script l1Script = new DeployL1Script();
@@ -29,6 +28,8 @@ contract L1ContractDeployer is Test {
 
         sharedBridgeProxyAddress = l1Script.getSharedBridgeProxyAddress();
         sharedBridge = L1SharedBridge(sharedBridgeProxyAddress);
+        sharedBridge.setEraPostLegacyBridgeUpgradeFirstBatch(1);
+        sharedBridge.setEraPostDiamondUpgradeFirstBatch(1);
     }
 
     function registerNewToken(address _tokenAddress) internal {
@@ -56,5 +57,20 @@ contract L1ContractDeployer is Test {
             .with_key(_chainId)
             .with_key(_token)
             .checked_write(_value);
+    }
+
+    function _setSharedBridgeIsWithdrawalFinalized(
+        uint256 _chainId,
+        uint256 _l2BatchNumber,
+        uint256 _l2ToL1MessageNumber,
+        bool _isFinalized
+    ) internal {
+        stdstore
+            .target(address(sharedBridge))
+            .sig(sharedBridge.isWithdrawalFinalized.selector)
+            .with_key(_chainId)
+            .with_key(_l2BatchNumber)
+            .with_key(_l2ToL1MessageNumber)
+            .checked_write(_isFinalized);
     }
 }

--- a/l1-contracts/test/foundry/integration/_SharedL1ContractDeployer.t.sol
+++ b/l1-contracts/test/foundry/integration/_SharedL1ContractDeployer.t.sol
@@ -2,11 +2,15 @@
 pragma solidity 0.8.24;
 
 import {Test} from "forge-std/Test.sol";
+import {StdStorage, stdStorage} from "forge-std/Test.sol";
+
 import {DeployL1Script} from "../../../scripts-rs/script/DeployL1.s.sol";
 import {Bridgehub} from "contracts/bridgehub/Bridgehub.sol";
 import {L1SharedBridge} from "contracts/bridge/L1SharedBridge.sol";
 
 contract L1ContractDeployer is Test {
+    using stdStorage for StdStorage;
+
     address bridgehubProxyAddress;
     address bridgehubOwnerAddress;
     Bridgehub bridgeHub;
@@ -42,5 +46,14 @@ contract L1ContractDeployer is Test {
     function registerL2SharedBridge(uint256 _chainId, address _l2SharedBridge) internal {
         vm.prank(bridgehubOwnerAddress);
         sharedBridge.initializeChainGovernance(_chainId, _l2SharedBridge);
+    }
+
+    function _setSharedBridgeChainBalance(uint256 _chainId, address _token, uint256 _value) internal {
+        stdstore
+            .target(address(sharedBridge))
+            .sig(sharedBridge.chainBalance.selector)
+            .with_key(_chainId)
+            .with_key(_token)
+            .checked_write(_value);
     }
 }

--- a/l1-contracts/test/foundry/integration/_SharedL1ContractDeployer.t.sol
+++ b/l1-contracts/test/foundry/integration/_SharedL1ContractDeployer.t.sol
@@ -11,8 +11,9 @@ contract L1ContractDeployer is Test {
     address bridgehubOwnerAddress;
     Bridgehub bridgeHub;
 
-    address sharedBridgeProxyAddress;
-    L1SharedBridge sharedBridge;
+    address public sharedBridgeProxyAddress;
+    L1SharedBridge public sharedBridge; 
+
 
     function deployL1Contracts() internal {
         DeployL1Script l1Script = new DeployL1Script();

--- a/l1-contracts/test/foundry/integration/_SharedL2TxMocker.t.sol
+++ b/l1-contracts/test/foundry/integration/_SharedL2TxMocker.t.sol
@@ -32,13 +32,12 @@ contract L2TxMocker is Test {
         chainContracts[_chainId] = _chainContract;
     }
 
-    function createL2TransitionRequestDirectSecond(
+    function createL2TransactionRequestDirect(
         uint256 _chainId,
         uint256 _mintValue,
         uint256 _l2Value,
         uint256 _l2GasLimit,
         uint256 _l2GasPerPubdataByteLimit,
-        address _tokenAddress,
         bytes memory _l2CallData
     ) internal returns (L2TransactionRequestDirect memory request) {
         request.chainId = _chainId;
@@ -55,13 +54,13 @@ contract L2TxMocker is Test {
     }
 
     function createMockL2TransactionRequestDirect(
-        uint256 chainId,
-        uint256 mintValue,
-        uint256 l2Value
+        uint256 _chainId,
+        uint256 _mintValue,
+        uint256 _l2Value
     ) internal returns (L2TransactionRequestDirect memory request) {
-        request.chainId = chainId;
-        request.mintValue = mintValue;
-        request.l2Value = l2Value;
+        request.chainId = _chainId;
+        request.mintValue = _mintValue;
+        request.l2Value = _l2Value;
 
         // mocks
         request.l2Contract = mockL2Contract;
@@ -72,7 +71,7 @@ contract L2TxMocker is Test {
         request.refundRecipient = mockRefundRecipient;
     }
 
-    function createMockL2TransactionRequestTwoBridgesSecond(
+    function createL2TransactionRequestTwoBridges(
         uint256 _chainId,
         uint256 _mintValue,
         uint256 _secondBridgeValue,
@@ -96,23 +95,23 @@ contract L2TxMocker is Test {
     }
 
     function createMockL2TransactionRequestTwoBridges(
-        uint256 chainId,
-        uint256 mintValue,
-        uint256 secondBridgeValue,
-        uint256 l2Value,
-        address secondBridgeAddress,
-        bytes memory secondBridgeCalldata
+        uint256 _chainId,
+        uint256 _mintValue,
+        uint256 _secondBridgeValue,
+        uint256 _l2Value,
+        address _secondBridgeAddress,
+        bytes memory _secondBridgeCalldata
     ) internal returns (L2TransactionRequestTwoBridgesOuter memory request) {
-        request.chainId = chainId;
-        request.mintValue = mintValue;
-        request.secondBridgeAddress = secondBridgeAddress;
-        request.secondBridgeValue = secondBridgeValue;
-        request.l2Value = l2Value;
+        request.chainId = _chainId;
+        request.mintValue = _mintValue;
+        request.secondBridgeAddress = _secondBridgeAddress;
+        request.secondBridgeValue = _secondBridgeValue;
+        request.l2Value = _l2Value;
+        request.secondBridgeCalldata = _secondBridgeCalldata;
 
         // mocks
         request.l2GasLimit = mockL2GasLimit;
         request.l2GasPerPubdataByteLimit = mockL2GasPerPubdataByteLimit;
         request.refundRecipient = mockRefundRecipient;
-        request.secondBridgeCalldata = secondBridgeCalldata;
     }
 }

--- a/l1-contracts/test/foundry/integration/_SharedL2TxMocker.t.sol
+++ b/l1-contracts/test/foundry/integration/_SharedL2TxMocker.t.sol
@@ -26,6 +26,27 @@ contract L2TxMocker is Test {
         mockFactoryDeps[0] = "11111111111111111111111111111111";
     }
 
+    function createL2TransitionRequestDirectSecond(
+        uint256 _chainId,
+        uint256 _mintValue,
+        uint256 _l2Value,
+        uint256 _l2GasLimit,
+        uint256 _l2GasPerPubdataByteLimit
+    ) internal returns (L2TransactionRequestDirect memory request) {
+        request.chainId = _chainId;
+        request.mintValue = _mintValue;
+        request.l2Value = _l2Value;
+        request.l2GasLimit = _l2GasLimit;
+        request.l2GasPerPubdataByteLimit = _l2GasPerPubdataByteLimit;
+
+        // mocks
+        request.l2Contract = mockL2Contract;
+        request.l2Calldata = mockL2Calldata;
+        request.factoryDeps = mockFactoryDeps;
+        request.refundRecipient = mockRefundRecipient;
+    
+    }
+
     function createMockL2TransactionRequestDirect(
         uint256 chainId,
         uint256 mintValue,

--- a/l1-contracts/test/foundry/integration/_SharedL2TxMocker.t.sol
+++ b/l1-contracts/test/foundry/integration/_SharedL2TxMocker.t.sol
@@ -16,6 +16,8 @@ contract L2TxMocker is Test {
     bytes mockL2Calldata;
     bytes[] mockFactoryDeps;
 
+    mapping(uint256 chainId => address l2MockContract) public chainContracts;
+
     constructor() {
         mockRefundRecipient = makeAddr("refundrecipient");
         mockL2Contract = makeAddr("mockl2contract");
@@ -24,6 +26,10 @@ contract L2TxMocker is Test {
         mockL2Calldata = "";
         mockFactoryDeps = new bytes[](1);
         mockFactoryDeps[0] = "11111111111111111111111111111111";
+    }
+
+    function addL2ChainContract(uint256 _chainId, address _chainContract) internal {
+        chainContracts[_chainId] = _chainContract;
     }
 
     function createL2TransitionRequestDirectSecond(
@@ -38,13 +44,12 @@ contract L2TxMocker is Test {
         request.l2Value = _l2Value;
         request.l2GasLimit = _l2GasLimit;
         request.l2GasPerPubdataByteLimit = _l2GasPerPubdataByteLimit;
+        request.l2Contract = chainContracts[_chainId];
 
-        // mocks
-        request.l2Contract = mockL2Contract;
+        //
         request.l2Calldata = mockL2Calldata;
         request.factoryDeps = mockFactoryDeps;
         request.refundRecipient = mockRefundRecipient;
-    
     }
 
     function createMockL2TransactionRequestDirect(

--- a/l1-contracts/test/foundry/integration/_SharedL2TxMocker.t.sol
+++ b/l1-contracts/test/foundry/integration/_SharedL2TxMocker.t.sol
@@ -37,7 +37,8 @@ contract L2TxMocker is Test {
         uint256 _mintValue,
         uint256 _l2Value,
         uint256 _l2GasLimit,
-        uint256 _l2GasPerPubdataByteLimit
+        uint256 _l2GasPerPubdataByteLimit,
+        address _tokenAddress
     ) internal returns (L2TransactionRequestDirect memory request) {
         request.chainId = _chainId;
         request.mintValue = _mintValue;
@@ -46,8 +47,9 @@ contract L2TxMocker is Test {
         request.l2GasPerPubdataByteLimit = _l2GasPerPubdataByteLimit;
         request.l2Contract = chainContracts[_chainId];
 
-        //
-        request.l2Calldata = mockL2Calldata;
+        // for mocking encode just tokenaddress of the token
+        request.l2Calldata = abi.encode(_tokenAddress);
+
         request.factoryDeps = mockFactoryDeps;
         request.refundRecipient = mockRefundRecipient;
     }

--- a/l1-contracts/test/foundry/integration/_SharedL2TxMocker.t.sol
+++ b/l1-contracts/test/foundry/integration/_SharedL2TxMocker.t.sol
@@ -38,7 +38,8 @@ contract L2TxMocker is Test {
         uint256 _l2Value,
         uint256 _l2GasLimit,
         uint256 _l2GasPerPubdataByteLimit,
-        address _tokenAddress
+        address _tokenAddress,
+        bytes memory _l2CallData
     ) internal returns (L2TransactionRequestDirect memory request) {
         request.chainId = _chainId;
         request.mintValue = _mintValue;
@@ -46,10 +47,9 @@ contract L2TxMocker is Test {
         request.l2GasLimit = _l2GasLimit;
         request.l2GasPerPubdataByteLimit = _l2GasPerPubdataByteLimit;
         request.l2Contract = chainContracts[_chainId];
+        request.l2Calldata = _l2CallData;
 
-        // for mocking encode just tokenaddress of the token
-        request.l2Calldata = abi.encode(_tokenAddress);
-
+        //mocked
         request.factoryDeps = mockFactoryDeps;
         request.refundRecipient = mockRefundRecipient;
     }
@@ -69,6 +69,29 @@ contract L2TxMocker is Test {
         request.l2GasLimit = mockL2GasLimit;
         request.l2GasPerPubdataByteLimit = REQUIRED_L2_GAS_PRICE_PER_PUBDATA;
         request.factoryDeps = mockFactoryDeps;
+        request.refundRecipient = mockRefundRecipient;
+    }
+
+    function createMockL2TransactionRequestTwoBridgesSecond(
+        uint256 _chainId,
+        uint256 _mintValue,
+        uint256 _secondBridgeValue,
+        address _secondBridgeAddress,
+        uint256 _l2Value,
+        uint256 _l2GasLimit,
+        uint256 _l2GasPerPubdataByteLimit,
+        bytes memory _secondBridgeCalldata
+    ) internal returns (L2TransactionRequestTwoBridgesOuter memory request) {
+        request.chainId = _chainId;
+        request.mintValue = _mintValue;
+        request.secondBridgeAddress = _secondBridgeAddress;
+        request.secondBridgeValue = _secondBridgeValue;
+        request.l2Value = _l2Value;
+        request.l2GasLimit = _l2GasLimit;
+        request.l2GasPerPubdataByteLimit = _l2GasPerPubdataByteLimit;
+        request.secondBridgeCalldata = _secondBridgeCalldata;
+
+        //mocks
         request.refundRecipient = mockRefundRecipient;
     }
 

--- a/l1-contracts/test/foundry/integration/deploy-scripts/script-config/config-deploy-l1.toml
+++ b/l1-contracts/test/foundry/integration/deploy-scripts/script-config/config-deploy-l1.toml
@@ -15,6 +15,7 @@ latest_protocol_version = 0
 recursion_node_level_vk_hash = "0x0000000000000000000000000000000000000000000000000000000000000000"
 recursion_leaf_level_vk_hash = "0x0000000000000000000000000000000000000000000000000000000000000000"
 recursion_circuits_set_vks_hash = "0x0000000000000000000000000000000000000000000000000000000000000000"
+verifier_implementation = "TestnetVerifier.sol"
 priority_tx_max_gas_limit = 80000000
 diamond_init_pubdata_pricing_mode = 0
 diamond_init_batch_overhead_l1_gas = 1000000

--- a/l1-contracts/test/foundry/integration/deploy-scripts/script/DeployL1.s.sol
+++ b/l1-contracts/test/foundry/integration/deploy-scripts/script/DeployL1.s.sol
@@ -10,8 +10,6 @@ import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transpa
 
 import {Utils} from "./Utils.sol";
 import {Multicall3} from "contracts/dev-contracts/Multicall3.sol";
-import {TestnetVerifier} from "contracts/state-transition/TestnetVerifier.sol";
-import {Verifier} from "contracts/state-transition/Verifier.sol";
 import {VerifierParams, IVerifier} from "contracts/state-transition/chain-interfaces/IVerifier.sol";
 import {DefaultUpgrade} from "contracts/upgrades/DefaultUpgrade.sol";
 import {Governance} from "contracts/governance/Governance.sol";

--- a/l1-contracts/test/foundry/integration/deploy-scripts/script/DeployL1.s.sol
+++ b/l1-contracts/test/foundry/integration/deploy-scripts/script/DeployL1.s.sol
@@ -10,6 +10,7 @@ import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transpa
 
 import {Utils} from "./Utils.sol";
 import {Multicall3} from "contracts/dev-contracts/Multicall3.sol";
+import {TestnetVerifier} from "contracts/state-transition/TestnetVerifier.sol";
 import {Verifier} from "contracts/state-transition/Verifier.sol";
 import {VerifierParams, IVerifier} from "contracts/state-transition/chain-interfaces/IVerifier.sol";
 import {DefaultUpgrade} from "contracts/upgrades/DefaultUpgrade.sol";
@@ -96,6 +97,7 @@ contract DeployL1Script is Script {
         bytes32 recursionNodeLevelVkHash;
         bytes32 recursionLeafLevelVkHash;
         bytes32 recursionCircuitsSetVksHash;
+        string validatorImplementation;
         uint256 priorityTxMaxGasLimit;
         PubdataPricingMode diamondInitPubdataPricingMode;
         uint256 diamondInitBatchOverheadL1Gas;
@@ -197,6 +199,7 @@ contract DeployL1Script is Script {
         config.contracts.recursionNodeLevelVkHash = toml.readBytes32("$.contracts.recursion_node_level_vk_hash");
         config.contracts.recursionLeafLevelVkHash = toml.readBytes32("$.contracts.recursion_leaf_level_vk_hash");
         config.contracts.recursionCircuitsSetVksHash = toml.readBytes32("$.contracts.recursion_circuits_set_vks_hash");
+        config.contracts.validatorImplementation = toml.readString("$.contracts.verifier_implementation");
         config.contracts.priorityTxMaxGasLimit = toml.readUint("$.contracts.priority_tx_max_gas_limit");
         config.contracts.diamondInitPubdataPricingMode = PubdataPricingMode(
             toml.readUint("$.contracts.diamond_init_pubdata_pricing_mode")
@@ -251,7 +254,7 @@ contract DeployL1Script is Script {
     }
 
     function deployVerifier() internal {
-        address contractAddress = deployViaCreate2(type(Verifier).creationCode);
+        address contractAddress = deployViaCreate2(vm.getCode(config.contracts.validatorImplementation));
         console.log("Verifier deployed at:", contractAddress);
         addresses.stateTransition.verifier = contractAddress;
     }


### PR DESCRIPTION
# What ❔

This PR introduces invariant tests with fuzzed inputs to test the integration of hyperchains. These tests involve depositing and withdrawing tokens through the bridgehub interface. The primary functionality is based on selecting random calls from the withdraw/deposit functions, executing the calls, and verifying how balances change after each call and if the invariants are kept.

## Type of deposits:
- depositERC20
- depositETH

## Type of withdrawals
- withdrawETH
- withdrawERC20

 Calls such as deposit and withdraw are categorized based on the type of token used (ERC20/ETH). Additionally, deposit functions consider whether the token is base or non-base and select the appropriate call.