### PR TITLE
Bridgehub test coverage increase + change in bridgehub!

### DIFF
--- a/l1-contracts/contracts/bridgehub/Bridgehub.sol
+++ b/l1-contracts/contracts/bridgehub/Bridgehub.sol
@@ -288,6 +288,11 @@ contract Bridgehub is IBridgehub, ReentrancyGuard, Ownable2StepUpgradeable, Paus
 
         address hyperchain = getHyperchain(_request.chainId);
 
+        require(
+            _request.secondBridgeAddress > BRIDGEHUB_MIN_SECOND_BRIDGE_ADDRESS,
+            "Bridgehub: second bridge address too low"
+        ); // to avoid calls to precompiles
+
         // slither-disable-next-line arbitrary-send-eth
         L2TransactionRequestTwoBridgesInner memory outputRequest = IL1SharedBridge(_request.secondBridgeAddress)
             .bridgehubDeposit{value: _request.secondBridgeValue}(
@@ -301,10 +306,6 @@ contract Bridgehub is IBridgehub, ReentrancyGuard, Ownable2StepUpgradeable, Paus
 
         address refundRecipient = AddressAliasHelper.actualRefundRecipient(_request.refundRecipient, msg.sender);
 
-        require(
-            _request.secondBridgeAddress > BRIDGEHUB_MIN_SECOND_BRIDGE_ADDRESS,
-            "Bridgehub: second bridge address too low"
-        ); // to avoid calls to precompiles
         canonicalTxHash = IZkSyncHyperchain(hyperchain).bridgehubRequestL2Transaction(
             BridgehubL2TransactionRequest({
                 sender: _request.secondBridgeAddress,

--- a/l1-contracts/contracts/dev-contracts/test/DummySharedBridge.sol
+++ b/l1-contracts/contracts/dev-contracts/test/DummySharedBridge.sol
@@ -5,7 +5,8 @@ pragma solidity 0.8.24;
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import {L2TransactionRequestTwoBridgesInner} from "../../bridgehub/IBridgehub.sol";
-import {TWO_BRIDGES_MAGIC_VALUE} from "../../common/Config.sol";
+import {TWO_BRIDGES_MAGIC_VALUE, ETH_TOKEN_ADDRESS} from "../../common/Config.sol";
+import {IL2Bridge} from "../../bridge/interfaces/IL2Bridge.sol";
 
 contract DummySharedBridge {
     event BridgehubDepositBaseTokenInitiated(
@@ -108,14 +109,33 @@ contract DummySharedBridge {
     }
 
     function bridgehubDeposit(
-        uint256, //_chainId,
-        address, //_prevMsgSender,
-        uint256, // l2Value, needed for Weth deposits in the future
-        bytes calldata //_data
+        uint256,
+        address _prevMsgSender,
+        uint256,
+        bytes calldata _data
     ) external payable returns (L2TransactionRequestTwoBridgesInner memory request) {
-        // Request the finalization of the deposit on the L2 side
-        bytes memory l2TxCalldata = bytes("0xabcd123");
-        bytes32 txDataHash = bytes32("0x1212121212abf");
+        (address _l1Token, uint256 _depositAmount, address _l2Receiver) = abi.decode(
+            _data,
+            (address, uint256, address)
+        );
+        uint256 amount;
+
+        if (_l1Token == ETH_TOKEN_ADDRESS) {
+            amount = msg.value;
+            require(_depositAmount == 0, "ShB wrong withdraw amount");
+        } else {
+            require(msg.value == 0, "ShB m.v > 0 for BH d.it 2");
+            amount = _depositAmount;
+
+            uint256 withdrawAmount = _depositFunds(_prevMsgSender, IERC20(_l1Token), _depositAmount);
+            require(withdrawAmount == _depositAmount, "5T"); // The token has non-standard transfer logic
+        }
+
+        bytes memory l2TxCalldata = abi.encodeCall(
+            IL2Bridge.finalizeDeposit,
+            (_prevMsgSender, _l2Receiver, _l1Token, amount, new bytes(0))
+        );
+        bytes32 txDataHash = keccak256(abi.encode(_prevMsgSender, _l1Token, amount));
 
         request = L2TransactionRequestTwoBridgesInner({
             magicValue: TWO_BRIDGES_MAGIC_VALUE,

--- a/l1-contracts/test/foundry/unit/concrete/Bridgehub/experimental_bridge.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/Bridgehub/experimental_bridge.t.sol
@@ -12,9 +12,9 @@ import {DummyStateTransitionManagerWBH} from "contracts/dev-contracts/test/Dummy
 import {DummyHyperchain} from "contracts/dev-contracts/test/DummyHyperchain.sol";
 import {DummySharedBridge} from "contracts/dev-contracts/test/DummySharedBridge.sol";
 import {IL1SharedBridge} from "contracts/bridge/interfaces/IL1SharedBridge.sol";
-
+import {L2TransactionRequestTwoBridgesInner} from "contracts/bridgehub/IBridgehub.sol";
 import {L2Message, L2Log, TxStatus, BridgehubL2TransactionRequest} from "contracts/common/Messaging.sol";
-import {ETH_TOKEN_ADDRESS, REQUIRED_L2_GAS_PRICE_PER_PUBDATA, MAX_NEW_FACTORY_DEPS} from "contracts/common/Config.sol";
+import {ETH_TOKEN_ADDRESS, REQUIRED_L2_GAS_PRICE_PER_PUBDATA, MAX_NEW_FACTORY_DEPS, TWO_BRIDGES_MAGIC_VALUE} from "contracts/common/Config.sol";
 
 contract ExperimentalBridgeTest is Test {
     using stdStorage for StdStorage;
@@ -907,6 +907,61 @@ contract ExperimentalBridgeTest is Test {
         assertEq(canonicalHash, resultantHash);
     }
 
+    function test_requestTransactionTwoBridgesChecksMagicValue(
+        uint256 chainId,
+        uint256 mintValue,
+        uint256 l2Value,
+        uint256 l2GasLimit,
+        uint256 l2GasPerPubdataByteLimit,
+        address refundRecipient,
+        uint256 secondBridgeValue,
+        bytes memory secondBridgeCalldata,
+        bytes32 magicValue
+    ) public {
+        L2TransactionRequestTwoBridgesOuter memory l2TxnReq2BridgeOut = _createMockL2TransactionRequestTwoBridgesOuter({
+            chainId: chainId,
+            mintValue: mintValue,
+            l2Value: l2Value,
+            l2GasLimit: l2GasLimit,
+            l2GasPerPubdataByteLimit: l2GasPerPubdataByteLimit,
+            refundRecipient: refundRecipient,
+            secondBridgeValue: secondBridgeValue,
+            secondBridgeCalldata: secondBridgeCalldata
+        });
+
+        l2TxnReq2BridgeOut.chainId = _setUpHyperchainForChainId(l2TxnReq2BridgeOut.chainId);
+
+        _setUpBaseTokenForChainId(l2TxnReq2BridgeOut.chainId, true);
+        assertTrue(bridgeHub.baseToken(l2TxnReq2BridgeOut.chainId) == ETH_TOKEN_ADDRESS);
+
+        _setUpSharedBridge();
+        assertTrue(bridgeHub.getHyperchain(l2TxnReq2BridgeOut.chainId) == address(mockChainContract));
+
+        uint256 callerMsgValue = l2TxnReq2BridgeOut.mintValue + l2TxnReq2BridgeOut.secondBridgeValue;
+        address randomCaller = makeAddr("RANDOM_CALLER");
+        vm.deal(randomCaller, callerMsgValue);
+
+        if (magicValue != TWO_BRIDGES_MAGIC_VALUE) {
+            L2TransactionRequestTwoBridgesInner memory request = L2TransactionRequestTwoBridgesInner({
+                magicValue: magicValue,
+                l2Contract: makeAddr("L2_CONTRACT"),
+                l2Calldata: new bytes(0),
+                factoryDeps: new bytes[](0),
+                txDataHash: bytes32(0)
+            });
+
+            vm.mockCall(
+                address(mockSecondSharedBridge),
+                abi.encodeWithSelector(IL1SharedBridge.bridgehubDeposit.selector),
+                abi.encode(request)
+            );
+
+            vm.expectRevert("Bridgehub: magic value mismatch");
+            vm.prank(randomCaller);
+            bridgeHub.requestL2TransactionTwoBridges{value: randomCaller.balance}(l2TxnReq2BridgeOut);
+        }
+    }
+
     function test_requestL2TransactionTwoBridges_ETHCase(
         uint256 chainId,
         uint256 mintValue,
@@ -915,6 +970,7 @@ contract ExperimentalBridgeTest is Test {
         uint256 l2GasPerPubdataByteLimit,
         address refundRecipient,
         uint256 secondBridgeValue,
+        uint160 secondBridgeAddressValue,
         bytes memory secondBridgeCalldata
     ) public {
         L2TransactionRequestTwoBridgesOuter memory l2TxnReq2BridgeOut = _createMockL2TransactionRequestTwoBridgesOuter({
@@ -950,11 +1006,15 @@ contract ExperimentalBridgeTest is Test {
             abi.encode(canonicalHash)
         );
 
-        vm.prank(randomCaller);
-        //bytes32 resultantHash =
-        bridgeHub.requestL2TransactionTwoBridges{value: randomCaller.balance}(l2TxnReq2BridgeOut);
-
-        assertTrue(true);
+        if (secondBridgeAddressValue <= uint160(type(uint16).max)) {
+            l2TxnReq2BridgeOut.secondBridgeAddress = address(secondBridgeAddressValue);
+            vm.expectRevert("Bridgehub: second bridge address too low");
+            vm.prank(randomCaller);
+            bridgeHub.requestL2TransactionTwoBridges{value: randomCaller.balance}(l2TxnReq2BridgeOut);
+        } else {
+            vm.prank(randomCaller);
+            bridgeHub.requestL2TransactionTwoBridges{value: randomCaller.balance}(l2TxnReq2BridgeOut);
+        }
     }
 
     /////////////////////////////////////////////////////////

--- a/l1-contracts/test/foundry/unit/concrete/Bridgehub/experimental_bridge.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/Bridgehub/experimental_bridge.t.sol
@@ -29,6 +29,8 @@ contract ExperimentalBridgeTest is Test {
 
     uint256 eraChainId;
 
+    event NewChain(uint256 indexed chainId, address stateTransitionManager, address indexed chainGovernance);
+
     function setUp() public {
         eraChainId = 9;
         bridgeHub = new Bridgehub();
@@ -73,6 +75,7 @@ contract ExperimentalBridgeTest is Test {
 
     function test_onlyOwnerCanSetDeployer(address randomDeployer) public {
         assertEq(address(0), bridgeHub.admin());
+
         vm.prank(bridgeHub.owner());
         bridgeHub.setPendingAdmin(randomDeployer);
         vm.prank(randomDeployer);
@@ -319,6 +322,182 @@ contract ExperimentalBridgeTest is Test {
     uint256 newChainId;
     address admin;
 
+    function test_pause_createNewChain() public {
+        address deployerAddress = makeAddr("DEPLOYER_ADDRESS");
+        admin = makeAddr("NEW_CHAIN_ADMIN");
+
+        vm.prank(bridgeOwner);
+        bridgeHub.pause();
+        vm.prank(bridgeOwner);
+        bridgeHub.setPendingAdmin(deployerAddress);
+        vm.prank(deployerAddress);
+        bridgeHub.acceptAdmin();
+
+        vm.expectRevert("Pausable: paused");
+        vm.prank(deployerAddress);
+        bridgeHub.createNewChain({
+            _chainId: 1,
+            _stateTransitionManager: address(mockSTM),
+            _baseToken: address(testToken),
+            _salt: uint256(123),
+            _admin: admin,
+            _initData: bytes("")
+        });
+
+        vm.prank(bridgeOwner);
+        bridgeHub.unpause();
+
+        vm.expectRevert("Bridgehub: state transition not registered");
+        vm.prank(deployerAddress);
+        bridgeHub.createNewChain({
+            _chainId: 1,
+            _stateTransitionManager: address(mockSTM),
+            _baseToken: address(testToken),
+            _salt: uint256(123),
+            _admin: admin,
+            _initData: bytes("")
+        });
+    }
+
+    function test_RevertWhen_STMNotRegisteredOnCreate(uint256 chainId) public {
+        address deployerAddress = makeAddr("DEPLOYER_ADDRESS");
+        admin = makeAddr("NEW_CHAIN_ADMIN");
+
+        vm.prank(bridgeOwner);
+        bridgeHub.setPendingAdmin(deployerAddress);
+        vm.prank(deployerAddress);
+        bridgeHub.acceptAdmin();
+
+        chainId = bound(chainId, 1, type(uint48).max);
+        vm.expectRevert("Bridgehub: state transition not registered");
+        vm.prank(deployerAddress);
+        bridgeHub.createNewChain({
+            _chainId: chainId,
+            _stateTransitionManager: address(mockSTM),
+            _baseToken: address(testToken),
+            _salt: uint256(123),
+            _admin: admin,
+            _initData: bytes("")
+        });
+    }
+
+    function test_RevertWhen_wrongChainIdOnCreate(uint256 chainId) public {
+        address deployerAddress = makeAddr("DEPLOYER_ADDRESS");
+        admin = makeAddr("NEW_CHAIN_ADMIN");
+
+        vm.prank(bridgeOwner);
+        bridgeHub.setPendingAdmin(deployerAddress);
+        vm.prank(deployerAddress);
+        bridgeHub.acceptAdmin();
+
+        chainId = bound(chainId, type(uint48).max + uint256(1), type(uint256).max);
+        vm.expectRevert("Bridgehub: chainId too large");
+        vm.prank(deployerAddress);
+        bridgeHub.createNewChain({
+            _chainId: chainId,
+            _stateTransitionManager: address(mockSTM),
+            _baseToken: address(testToken),
+            _salt: uint256(123),
+            _admin: admin,
+            _initData: bytes("")
+        });
+
+        chainId = 0;
+        vm.expectRevert("Bridgehub: chainId cannot be 0");
+        vm.prank(deployerAddress);
+        bridgeHub.createNewChain({
+            _chainId: chainId,
+            _stateTransitionManager: address(mockSTM),
+            _baseToken: address(testToken),
+            _salt: uint256(123),
+            _admin: admin,
+            _initData: bytes("")
+        });
+    }
+
+    function test_RevertWhen_tokenNotRegistered() public {
+        address deployerAddress = makeAddr("DEPLOYER_ADDRESS");
+        admin = makeAddr("NEW_CHAIN_ADMIN");
+
+        vm.prank(bridgeOwner);
+        bridgeHub.setPendingAdmin(deployerAddress);
+        vm.prank(deployerAddress);
+        bridgeHub.acceptAdmin();
+
+        vm.startPrank(bridgeOwner);
+        bridgeHub.addStateTransitionManager(address(mockSTM));
+        vm.stopPrank();
+
+        vm.expectRevert("Bridgehub: token not registered");
+        vm.prank(deployerAddress);
+        bridgeHub.createNewChain({
+            _chainId: 1,
+            _stateTransitionManager: address(mockSTM),
+            _baseToken: address(testToken),
+            _salt: uint256(123),
+            _admin: admin,
+            _initData: bytes("")
+        });
+    }
+
+    function test_RevertWhen_wethBridgeNotSet() public {
+        address deployerAddress = makeAddr("DEPLOYER_ADDRESS");
+        admin = makeAddr("NEW_CHAIN_ADMIN");
+
+        vm.prank(bridgeOwner);
+        bridgeHub.setPendingAdmin(deployerAddress);
+        vm.prank(deployerAddress);
+        bridgeHub.acceptAdmin();
+
+        vm.startPrank(bridgeOwner);
+        bridgeHub.addStateTransitionManager(address(mockSTM));
+        bridgeHub.addToken(address(testToken));
+        vm.stopPrank();
+
+        vm.expectRevert("Bridgehub: weth bridge not set");
+        vm.prank(deployerAddress);
+        bridgeHub.createNewChain({
+            _chainId: 1,
+            _stateTransitionManager: address(mockSTM),
+            _baseToken: address(testToken),
+            _salt: uint256(123),
+            _admin: admin,
+            _initData: bytes("")
+        });
+    }
+
+    function test_RevertWhen_chainIdAlreadyRegistered(uint256 chainId) public {
+        address deployerAddress = makeAddr("DEPLOYER_ADDRESS");
+        admin = makeAddr("NEW_CHAIN_ADMIN");
+
+        vm.prank(bridgeOwner);
+        bridgeHub.setPendingAdmin(deployerAddress);
+        vm.prank(deployerAddress);
+        bridgeHub.acceptAdmin();
+
+        vm.startPrank(bridgeOwner);
+        bridgeHub.addStateTransitionManager(address(mockSTM));
+        bridgeHub.addToken(address(testToken));
+        bridgeHub.setSharedBridge(address(mockSharedBridge));
+        vm.stopPrank();
+
+        chainId = bound(chainId, 1, type(uint48).max);
+        stdstore.target(address(bridgeHub)).sig("stateTransitionManager(uint256)").with_key(chainId).checked_write(
+            address(mockSTM)
+        );
+
+        vm.expectRevert("Bridgehub: chainId already registered");
+        vm.prank(deployerAddress);
+        bridgeHub.createNewChain({
+            _chainId: chainId,
+            _stateTransitionManager: address(mockSTM),
+            _baseToken: address(testToken),
+            _salt: uint256(123),
+            _admin: admin,
+            _initData: bytes("")
+        });
+    }
+
     function test_createNewChain(
         address randomCaller,
         uint256 chainId,
@@ -335,6 +514,7 @@ contract ExperimentalBridgeTest is Test {
         bridgeHub.setPendingAdmin(deployerAddress);
         vm.prank(deployerAddress);
         bridgeHub.acceptAdmin();
+
         vm.startPrank(bridgeOwner);
         bridgeHub.addStateTransitionManager(address(mockSTM));
         bridgeHub.addToken(address(testToken));
@@ -382,6 +562,9 @@ contract ExperimentalBridgeTest is Test {
             ),
             bytes("")
         );
+
+        vm.expectEmit(true, true, true, true, address(bridgeHub));
+        emit NewChain(chainId, address(mockSTM), admin);
 
         newChainId = bridgeHub.createNewChain({
             _chainId: chainId,
@@ -588,6 +771,7 @@ contract ExperimentalBridgeTest is Test {
     function test_requestL2TransactionDirect_ETHCase(
         uint256 mockChainId,
         uint256 mockMintValue,
+        uint256 msgValue,
         address mockL2Contract,
         uint256 mockL2Value,
         bytes memory mockL2Calldata,
@@ -622,7 +806,6 @@ contract ExperimentalBridgeTest is Test {
         _setUpSharedBridge();
 
         address randomCaller = makeAddr("RANDOM_CALLER");
-        vm.deal(randomCaller, l2TxnReqDirect.mintValue);
 
         assertTrue(bridgeHub.getHyperchain(l2TxnReqDirect.chainId) == address(mockChainContract));
         bytes32 canonicalHash = keccak256(abi.encode("CANONICAL_TX_HASH"));
@@ -640,8 +823,15 @@ contract ExperimentalBridgeTest is Test {
         mockChainContract.setBridgeHubAddress(address(bridgeHub));
         assertTrue(mockChainContract.getBridgeHubAddress() == address(bridgeHub));
 
-        vm.txGasPrice(0.05 ether);
+        if (msgValue != mockMintValue) {
+            vm.deal(randomCaller, msgValue);
+            vm.expectRevert("Bridgehub: msg.value mismatch 1");
+            vm.prank(randomCaller);
+            bridgeHub.requestL2TransactionDirect{value: msgValue}(l2TxnReqDirect);
+        }
 
+        vm.deal(randomCaller, l2TxnReqDirect.mintValue);
+        vm.txGasPrice(0.05 ether);
         vm.prank(randomCaller);
         bytes32 resultantHash = bridgeHub.requestL2TransactionDirect{value: randomCaller.balance}(l2TxnReqDirect);
 

--- a/l1-contracts/test/foundry/unit/concrete/Bridgehub/experimental_bridge.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/Bridgehub/experimental_bridge.t.sol
@@ -73,6 +73,42 @@ contract ExperimentalBridgeTest is Test {
         assertEq(bridgeHub.owner(), bridgeOwner);
     }
 
+    function test_newPendingAdminReplacesPrevious(address randomDeployer, address otherRandomDeployer) public {
+        assertEq(address(0), bridgeHub.admin());
+
+        if (randomDeployer == otherRandomDeployer) {
+            return;
+        }
+
+        vm.prank(bridgeHub.owner());
+        bridgeHub.setPendingAdmin(randomDeployer);
+
+        vm.prank(bridgeHub.owner());
+        bridgeHub.setPendingAdmin(otherRandomDeployer);
+
+        vm.prank(otherRandomDeployer);
+        bridgeHub.acceptAdmin();
+
+        assertEq(otherRandomDeployer, bridgeHub.admin());
+    }
+
+    function test_onlyPendingAdminCanAccept(address randomDeployer, address otherRandomDeployer) public {
+        assertEq(address(0), bridgeHub.admin());
+
+        vm.prank(bridgeHub.owner());
+        bridgeHub.setPendingAdmin(randomDeployer);
+
+        if (randomDeployer == otherRandomDeployer) {
+            return;
+        }
+
+        vm.expectRevert(bytes("n42"));
+        vm.prank(otherRandomDeployer);
+        bridgeHub.acceptAdmin();
+
+        assertEq(address(0), bridgeHub.admin());
+    }
+
     function test_onlyOwnerCanSetDeployer(address randomDeployer) public {
         assertEq(address(0), bridgeHub.admin());
 
@@ -962,9 +998,10 @@ contract ExperimentalBridgeTest is Test {
         }
     }
 
-    function test_requestL2TransactionTwoBridges_ETHCase(
+    function test_requestL2TransactionTwoBridgesWrongBridgeAddress(
         uint256 chainId,
         uint256 mintValue,
+        uint256 msgValue,
         uint256 l2Value,
         uint256 l2GasLimit,
         uint256 l2GasPerPubdataByteLimit,
@@ -1011,10 +1048,123 @@ contract ExperimentalBridgeTest is Test {
             vm.expectRevert("Bridgehub: second bridge address too low");
             vm.prank(randomCaller);
             bridgeHub.requestL2TransactionTwoBridges{value: randomCaller.balance}(l2TxnReq2BridgeOut);
-        } else {
-            vm.prank(randomCaller);
-            bridgeHub.requestL2TransactionTwoBridges{value: randomCaller.balance}(l2TxnReq2BridgeOut);
         }
+    }
+
+    function test_requestL2TransactionTwoBridges_ETHCase(
+        uint256 chainId,
+        uint256 mintValue,
+        uint256 msgValue,
+        uint256 l2Value,
+        uint256 l2GasLimit,
+        uint256 l2GasPerPubdataByteLimit,
+        address refundRecipient,
+        uint256 secondBridgeValue,
+        bytes memory secondBridgeCalldata
+    ) public {
+        L2TransactionRequestTwoBridgesOuter memory l2TxnReq2BridgeOut = _createMockL2TransactionRequestTwoBridgesOuter({
+            chainId: chainId,
+            mintValue: mintValue,
+            l2Value: l2Value,
+            l2GasLimit: l2GasLimit,
+            l2GasPerPubdataByteLimit: l2GasPerPubdataByteLimit,
+            refundRecipient: refundRecipient,
+            secondBridgeValue: secondBridgeValue,
+            secondBridgeCalldata: secondBridgeCalldata
+        });
+
+        l2TxnReq2BridgeOut.chainId = _setUpHyperchainForChainId(l2TxnReq2BridgeOut.chainId);
+
+        _setUpBaseTokenForChainId(l2TxnReq2BridgeOut.chainId, true);
+        assertTrue(bridgeHub.baseToken(l2TxnReq2BridgeOut.chainId) == ETH_TOKEN_ADDRESS);
+
+        _setUpSharedBridge();
+        assertTrue(bridgeHub.getHyperchain(l2TxnReq2BridgeOut.chainId) == address(mockChainContract));
+
+        uint256 callerMsgValue = l2TxnReq2BridgeOut.mintValue + l2TxnReq2BridgeOut.secondBridgeValue;
+        address randomCaller = makeAddr("RANDOM_CALLER");
+
+        mockChainContract.setBridgeHubAddress(address(bridgeHub));
+
+        bytes32 canonicalHash = keccak256(abi.encode("CANONICAL_TX_HASH"));
+
+        vm.mockCall(
+            address(mockChainContract),
+            abi.encodeWithSelector(mockChainContract.bridgehubRequestL2Transaction.selector),
+            abi.encode(canonicalHash)
+        );
+
+        if (msgValue != (l2TxnReq2BridgeOut.mintValue + l2TxnReq2BridgeOut.secondBridgeValue)) {
+            vm.deal(randomCaller, msgValue);
+            vm.expectRevert("Bridgehub: msg.value mismatch 2");
+            vm.prank(randomCaller);
+            bridgeHub.requestL2TransactionTwoBridges{value: msgValue}(l2TxnReq2BridgeOut);
+        }
+
+        vm.deal(randomCaller, callerMsgValue);
+        vm.prank(randomCaller);
+        bridgeHub.requestL2TransactionTwoBridges{value: randomCaller.balance}(l2TxnReq2BridgeOut);
+    }
+
+    function test_requestL2TransactionTwoBridges_ETHToNonETHCase(
+        uint256 chainId,
+        uint256 mintValue,
+        uint256 msgValue,
+        uint256 l2Value,
+        uint256 l2GasLimit,
+        uint256 l2GasPerPubdataByteLimit,
+        address refundRecipient,
+        uint256 secondBridgeValue,
+        address l2Receiver
+    ) public {
+        bytes memory secondBridgeCalldata = abi.encode(ETH_TOKEN_ADDRESS, 0, l2Receiver);
+
+        L2TransactionRequestTwoBridgesOuter memory l2TxnReq2BridgeOut = _createMockL2TransactionRequestTwoBridgesOuter({
+            chainId: chainId,
+            mintValue: mintValue,
+            l2Value: l2Value,
+            l2GasLimit: l2GasLimit,
+            l2GasPerPubdataByteLimit: l2GasPerPubdataByteLimit,
+            refundRecipient: refundRecipient,
+            secondBridgeValue: secondBridgeValue,
+            secondBridgeCalldata: secondBridgeCalldata
+        });
+
+        l2TxnReq2BridgeOut.chainId = _setUpHyperchainForChainId(l2TxnReq2BridgeOut.chainId);
+
+        _setUpBaseTokenForChainId(l2TxnReq2BridgeOut.chainId, false);
+        assertTrue(bridgeHub.baseToken(l2TxnReq2BridgeOut.chainId) == address(testToken));
+
+        _setUpSharedBridge();
+        assertTrue(bridgeHub.getHyperchain(l2TxnReq2BridgeOut.chainId) == address(mockChainContract));
+
+        address randomCaller = makeAddr("RANDOM_CALLER");
+
+        mockChainContract.setBridgeHubAddress(address(bridgeHub));
+
+        bytes32 canonicalHash = keccak256(abi.encode("CANONICAL_TX_HASH"));
+
+        vm.mockCall(
+            address(mockChainContract),
+            abi.encodeWithSelector(mockChainContract.bridgehubRequestL2Transaction.selector),
+            abi.encode(canonicalHash)
+        );
+
+        if (msgValue != secondBridgeValue) {
+            vm.deal(randomCaller, msgValue);
+            vm.expectRevert("Bridgehub: msg.value mismatch 3");
+            vm.prank(randomCaller);
+            bridgeHub.requestL2TransactionTwoBridges{value: msgValue}(l2TxnReq2BridgeOut);
+        }
+
+        testToken.mint(randomCaller, l2TxnReq2BridgeOut.mintValue);
+        assertEq(testToken.balanceOf(randomCaller), l2TxnReq2BridgeOut.mintValue);
+        vm.prank(randomCaller);
+        testToken.approve(address(mockSharedBridge), l2TxnReq2BridgeOut.mintValue);
+
+        vm.deal(randomCaller, l2TxnReq2BridgeOut.secondBridgeValue);
+        vm.prank(randomCaller);
+        bridgeHub.requestL2TransactionTwoBridges{value: randomCaller.balance}(l2TxnReq2BridgeOut);
     }
 
     /////////////////////////////////////////////////////////

--- a/l1-contracts/test/foundry/unit/concrete/Bridgehub/experimental_bridge.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/Bridgehub/experimental_bridge.t.sol
@@ -1051,37 +1051,38 @@ contract ExperimentalBridgeTest is Test {
         }
     }
 
-    function test_requestL2TransactionTwoBridges_ETHCase(
+    function test_requestL2TransactionTwoBridges_ERC20ToNonBase(
         uint256 chainId,
         uint256 mintValue,
-        uint256 msgValue,
         uint256 l2Value,
         uint256 l2GasLimit,
         uint256 l2GasPerPubdataByteLimit,
         address refundRecipient,
-        uint256 secondBridgeValue,
-        bytes memory secondBridgeCalldata
+        address l2Receiver
     ) public {
+        TestnetERC20Token erc20Token = new TestnetERC20Token("ZKESTT", "ZkSync ERC Test Token", 18);
+        address erc20TokenAddress = address(erc20Token);
+        bytes memory secondBridgeCalldata = abi.encode(erc20TokenAddress, l2Value, l2Receiver);
+
         L2TransactionRequestTwoBridgesOuter memory l2TxnReq2BridgeOut = _createMockL2TransactionRequestTwoBridgesOuter({
             chainId: chainId,
             mintValue: mintValue,
-            l2Value: l2Value,
+            l2Value: 0, // not used
             l2GasLimit: l2GasLimit,
             l2GasPerPubdataByteLimit: l2GasPerPubdataByteLimit,
             refundRecipient: refundRecipient,
-            secondBridgeValue: secondBridgeValue,
+            secondBridgeValue: 0, // not used cause we are using ERC20
             secondBridgeCalldata: secondBridgeCalldata
         });
 
         l2TxnReq2BridgeOut.chainId = _setUpHyperchainForChainId(l2TxnReq2BridgeOut.chainId);
 
-        _setUpBaseTokenForChainId(l2TxnReq2BridgeOut.chainId, true);
-        assertTrue(bridgeHub.baseToken(l2TxnReq2BridgeOut.chainId) == ETH_TOKEN_ADDRESS);
+        _setUpBaseTokenForChainId(l2TxnReq2BridgeOut.chainId, false);
+        assertTrue(bridgeHub.baseToken(l2TxnReq2BridgeOut.chainId) == address(testToken));
 
         _setUpSharedBridge();
         assertTrue(bridgeHub.getHyperchain(l2TxnReq2BridgeOut.chainId) == address(mockChainContract));
 
-        uint256 callerMsgValue = l2TxnReq2BridgeOut.mintValue + l2TxnReq2BridgeOut.secondBridgeValue;
         address randomCaller = makeAddr("RANDOM_CALLER");
 
         mockChainContract.setBridgeHubAddress(address(bridgeHub));
@@ -1094,19 +1095,40 @@ contract ExperimentalBridgeTest is Test {
             abi.encode(canonicalHash)
         );
 
-        if (msgValue != (l2TxnReq2BridgeOut.mintValue + l2TxnReq2BridgeOut.secondBridgeValue)) {
-            vm.deal(randomCaller, msgValue);
-            vm.expectRevert("Bridgehub: msg.value mismatch 2");
-            vm.prank(randomCaller);
-            bridgeHub.requestL2TransactionTwoBridges{value: msgValue}(l2TxnReq2BridgeOut);
-        }
+        testToken.mint(randomCaller, l2TxnReq2BridgeOut.mintValue);
+        erc20Token.mint(randomCaller, l2Value);
 
-        vm.deal(randomCaller, callerMsgValue);
+        assertEq(testToken.balanceOf(randomCaller), l2TxnReq2BridgeOut.mintValue);
+        assertEq(erc20Token.balanceOf(randomCaller), l2Value);
+
+        vm.startPrank(randomCaller);
+        testToken.approve(address(mockSharedBridge), l2TxnReq2BridgeOut.mintValue);
+        erc20Token.approve(address(mockSecondSharedBridge), l2Value);
+        vm.stopPrank();
+
+        emit log_uint(erc20Token.balanceOf(randomCaller));
+
         vm.prank(randomCaller);
-        bridgeHub.requestL2TransactionTwoBridges{value: randomCaller.balance}(l2TxnReq2BridgeOut);
+        bytes32 resultHash = bridgeHub.requestL2TransactionTwoBridges(l2TxnReq2BridgeOut);
+        assertEq(resultHash, canonicalHash);
+
+        emit log_uint(erc20Token.balanceOf(randomCaller));
+
+        assert(erc20Token.balanceOf(randomCaller) == 0);
+        assert(testToken.balanceOf(randomCaller) == 0);
+        assert(erc20Token.balanceOf(address(mockSecondSharedBridge)) == l2Value);
+        assert(testToken.balanceOf(address(mockSharedBridge)) == l2TxnReq2BridgeOut.mintValue);
+
+        l2TxnReq2BridgeOut.secondBridgeValue = 1;
+        testToken.mint(randomCaller, l2TxnReq2BridgeOut.mintValue);
+        vm.startPrank(randomCaller);
+        testToken.approve(address(mockSharedBridge), l2TxnReq2BridgeOut.mintValue);
+        vm.expectRevert("Bridgehub: msg.value mismatch 3");
+        bridgeHub.requestL2TransactionTwoBridges(l2TxnReq2BridgeOut);
+        vm.stopPrank();
     }
 
-    function test_requestL2TransactionTwoBridges_ETHToNonETHCase(
+    function test_requestL2TransactionTwoBridges_ETHToNonBase(
         uint256 chainId,
         uint256 mintValue,
         uint256 msgValue,
@@ -1184,8 +1206,9 @@ contract ExperimentalBridgeTest is Test {
         L2TransactionRequestTwoBridgesOuter memory l2Req;
 
         // Don't let the mintValue + secondBridgeValue go beyond type(uint256).max since that calculation is required to be done by our test: test_requestL2TransactionTwoBridges_ETHCase
-        mintValue = bound(mintValue, 1, (type(uint256).max) / 2);
-        secondBridgeValue = bound(secondBridgeValue, 1, (type(uint256).max) / 2);
+
+        mintValue = bound(mintValue, 0, (type(uint256).max) / 2);
+        secondBridgeValue = bound(secondBridgeValue, 0, (type(uint256).max) / 2);
 
         l2Req.chainId = chainId;
         l2Req.mintValue = mintValue;


### PR DESCRIPTION
# What ❔

Increased coverage in bridgehub unit tests, add some cases for two bridges deposit.
Changed order of assert in Bridgehub contract.

## Why ❔

Previous tests had low coverage on branches, asserts and types of deposits, theirs permutations. 

## Checklist

- [x] overall tests to increase coverage
- [x] deposit eth using second bridge to non eth base chain
- [x] deposit nonbase  token using second bridge to some erc20 base chain
